### PR TITLE
Separate creation of training data and eval data and start eval_state skeleton

### DIFF
--- a/nssp_demo/eval_state.py
+++ b/nssp_demo/eval_state.py
@@ -24,15 +24,6 @@ def postprocess_forecast(model_run_dir: Path) -> None:
     return None
 
 
-# Test values
-state = state_abb = "CA"
-model_batch_dir_name = "influenza_r_2024-10-29_f_2023-10-30_t_2024-10-28"
-latest_comprehensive_path = (
-    "private_data/nssp-archival-vintages/latest_comprehensive.parquet"
-)
-output_data_dir = "private_data/pyrenew-test-output"
-
-
 def main(
     state: str,
     model_batch_dir_name: str,

--- a/nssp_demo/eval_state.py
+++ b/nssp_demo/eval_state.py
@@ -1,0 +1,15 @@
+import argparse
+import logging
+import os
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpyro
+import polars as pl
+from prep_data import process_and_save_state
+
+numpyro.set_host_device_count(4)
+
+from fit_model import fit_and_save_model  # noqa
+from generate_predictive import generate_and_save_predictions  # noqa

--- a/nssp_demo/eval_state.py
+++ b/nssp_demo/eval_state.py
@@ -13,3 +13,263 @@ numpyro.set_host_device_count(4)
 
 from fit_model import fit_and_save_model  # noqa
 from generate_predictive import generate_and_save_predictions  # noqa
+from forecast_state import get_available_reports  # noqa
+
+
+def postprocess_forecast(model_run_dir: Path) -> None:
+    subprocess.run(
+        [
+            "Rscript",
+            "nssp_demo/postprocess_state_forecast.R",
+            "--model-run-dir",
+            f"{model_run_dir}",
+        ]
+    )
+    return None
+
+
+def main(
+    disease: str,
+    report_date: str,
+    state: str,
+    model_batch_dir_name: str,
+    facility_level_nssp_data_dir: Path | str,
+    state_level_nssp_data_dir: Path | str,
+    param_data_dir: Path | str,
+    output_data_dir: Path | str,
+    n_training_days: int,
+    n_forecast_days: int,
+    n_chains: int,
+    n_warmup: int,
+    n_samples: int,
+    exclude_last_n_days: int = 0,
+):
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    available_facility_level_reports = get_available_reports(
+        facility_level_nssp_data_dir
+    )
+
+    available_state_level_reports = get_available_reports(
+        state_level_nssp_data_dir
+    )
+    first_available_state_report = min(available_state_level_reports)
+    last_available_state_report = max(available_state_level_reports)
+
+    if report_date == "latest":
+        report_date = max(available_facility_level_reports)
+    else:
+        report_date = datetime.strptime(report_date, "%Y-%m-%d").date()
+
+    if report_date in available_state_level_reports:
+        state_report_date = report_date
+    elif report_date > last_available_state_report:
+        state_report_date = last_available_state_report
+    elif report_date > first_available_state_report:
+        raise ValueError(
+            "Dataset appear to be missing some state-level "
+            f"reports. First entry is {first_available_state_report}, "
+            f"last is {last_available_state_report}, but no entry "
+            f"for {report_date}"
+        )
+    else:
+        raise ValueError(
+            "Requested report date is earlier than the first "
+            "state-level vintage. This is not currently supported"
+        )
+
+    logger.info(f"Report date: {report_date}")
+    if state_report_date is not None:
+        logger.info(f"Using state-level data as of: {state_report_date}")
+
+    # + 1 because max date in dataset is report_date - 1
+    last_training_date = report_date - timedelta(days=exclude_last_n_days + 1)
+
+    if last_training_date >= report_date:
+        raise ValueError(
+            "Last training date must be before the report date. "
+            "Got a last training date of {last_training_date} "
+            "with a report date of {report_date}."
+        )
+
+    logger.info(f"last training date: {last_training_date}")
+
+    first_training_date = last_training_date - timedelta(
+        days=n_training_days - 1
+    )
+
+    logger.info(f"First training date {first_training_date}")
+
+    facility_level_nssp_data, state_level_nssp_data = None, None
+
+    if report_date in available_facility_level_reports:
+        logger.info(
+            "Facility level data available for " "the given report date"
+        )
+        facility_datafile = f"{report_date}.parquet"
+        facility_level_nssp_data = pl.scan_parquet(
+            Path(facility_level_nssp_data_dir, facility_datafile)
+        )
+    if state_report_date in available_state_level_reports:
+        logger.info("State-level data available for the given report " "date.")
+        state_datafile = f"{state_report_date}.parquet"
+        state_level_nssp_data = pl.scan_parquet(
+            Path(state_level_nssp_data_dir, state_datafile)
+        )
+    if facility_level_nssp_data is None and state_level_nssp_data is None:
+        raise ValueError(
+            "No data available for the requested report date " f"{report_date}"
+        )
+
+    param_estimates = pl.scan_parquet(Path(param_data_dir, "prod.parquet"))
+
+    model_batch_dir = Path(output_data_dir, model_batch_dir_name)
+
+    model_run_dir = Path(model_batch_dir, state)
+
+    os.makedirs(model_run_dir, exist_ok=True)
+
+    logger.info(f"Processing {state}")
+    process_and_save_state(
+        state_abb=state,
+        disease=disease,
+        facility_level_nssp_data=facility_level_nssp_data,
+        state_level_nssp_data=state_level_nssp_data,
+        report_date=report_date,
+        state_level_report_date=state_report_date,
+        first_training_date=first_training_date,
+        last_training_date=last_training_date,
+        param_estimates=param_estimates,
+        model_batch_dir=model_batch_dir,
+        logger=logger,
+        mode="forecast",
+    )
+    logger.info("Data preparation complete.")
+
+    logger.info("Postprocessing forecast...")
+    postprocess_forecast(model_run_dir)
+    logger.info("Postprocessing complete.")
+    logger.info(
+        "Single state pipeline complete "
+        f"for state {state} with "
+        f"report date {report_date}."
+    )
+
+    return None
+
+
+parser = argparse.ArgumentParser(
+    description="Create fit data for disease modeling."
+)
+parser.add_argument(
+    "--disease",
+    type=str,
+    required=True,
+    help="Disease to model (e.g., COVID-19, Influenza, RSV).",
+)
+
+parser.add_argument(
+    "--state",
+    type=str,
+    required=True,
+    help=(
+        "Two letter abbreviation for the state to fit"
+        "(e.g. 'AK', 'AL', 'AZ', etc.)."
+    ),
+)
+
+parser.add_argument(
+    "--report-date",
+    type=str,
+    default="latest",
+    help="Report date in YYYY-MM-DD format or latest (default: latest).",
+)
+
+parser.add_argument(
+    "--facility-level-nssp-data-dir",
+    type=Path,
+    default=Path("private_data", "nssp_etl_gold"),
+    help=(
+        "Directory in which to look for facility-level NSSP " "ED visit data"
+    ),
+)
+
+parser.add_argument(
+    "--state-level-nssp-data-dir",
+    type=Path,
+    default=Path("private_data", "nssp_state_level_gold"),
+    help=("Directory in which to look for state-level NSSP " "ED visit data."),
+)
+
+parser.add_argument(
+    "--param-data-dir",
+    type=Path,
+    default=Path("private_data", "prod_param_estimates"),
+    help=(
+        "Directory in which to look for parameter estimates"
+        "such as delay PMFs."
+    ),
+)
+
+parser.add_argument(
+    "--output-data-dir",
+    type=Path,
+    default="private_data",
+    help="Directory in which to save output data.",
+)
+
+parser.add_argument(
+    "--n-training-days",
+    type=int,
+    default=180,
+    help="Number of training days (default: 180).",
+)
+
+parser.add_argument(
+    "--n-forecast-days",
+    type=int,
+    default=28,
+    help="Number of days ahead to forecast (default: 28).",
+)
+
+
+parser.add_argument(
+    "--n-chains",
+    type=int,
+    default=4,
+    help="Number of MCMC chains to run (default: 4).",
+)
+
+parser.add_argument(
+    "--n-warmup",
+    type=int,
+    default=1000,
+    help=("Number of warmup iterations per chain for NUTS" "(default: 1000)."),
+)
+
+parser.add_argument(
+    "--n-samples",
+    type=int,
+    default=1000,
+    help=(
+        "Number of posterior samples to draw per "
+        "chain using NUTS (default: 1000)."
+    ),
+)
+
+parser.add_argument(
+    "--exclude-last-n-days",
+    type=int,
+    default=0,
+    help=(
+        "Optionally exclude the final n days of available training "
+        "data (Default: 0, i.e. exclude no available data"
+    ),
+)
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    numpyro.set_host_device_count(args.n_chains)
+    main(**vars(args))

--- a/nssp_demo/forecast_state.py
+++ b/nssp_demo/forecast_state.py
@@ -147,6 +147,7 @@ def main(
     os.makedirs(model_run_dir, exist_ok=True)
 
     logger.info(f"Processing {state}")
+
     process_and_save_state(
         state_abb=state,
         disease=disease,
@@ -159,7 +160,6 @@ def main(
         param_estimates=param_estimates,
         model_batch_dir=model_batch_dir,
         logger=logger,
-        mode="forecast",
     )
     logger.info("Data preparation complete.")
 

--- a/nssp_demo/forecast_state.py
+++ b/nssp_demo/forecast_state.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import numpyro
 import polars as pl
-from prep_data import process_and_save_state
+from prep_data import format_model_batch_dir_name, process_and_save_state
 
 numpyro.set_host_device_count(4)
 
@@ -136,9 +136,8 @@ def main(
         )
 
     param_estimates = pl.scan_parquet(Path(param_data_dir, "prod.parquet"))
-    model_batch_dir_name = (
-        f"{disease.lower()}_r_{report_date}_f_"
-        f"{first_training_date}_t_{last_training_date}"
+    model_batch_dir_name = format_model_batch_dir_name(
+        disease, report_date, first_training_date, last_training_date
     )
 
     model_batch_dir = Path(output_data_dir, model_batch_dir_name)

--- a/nssp_demo/forecast_state.py
+++ b/nssp_demo/forecast_state.py
@@ -33,18 +33,6 @@ def forecast_denominator(
     return None
 
 
-def postprocess_forecast(model_run_dir: Path) -> None:
-    subprocess.run(
-        [
-            "Rscript",
-            "nssp_demo/postprocess_state_forecast.R",
-            "--model-run-dir",
-            f"{model_run_dir}",
-        ]
-    )
-    return None
-
-
 def get_available_reports(
     data_dir: str | Path, glob_pattern: str = "*.parquet"
 ):
@@ -193,9 +181,6 @@ def main(
     forecast_denominator(model_run_dir, n_forecast_days, n_denominator_samples)
     logger.info("Forecasting complete.")
 
-    logger.info("Postprocessing forecast...")
-    postprocess_forecast(model_run_dir)
-    logger.info("Postprocessing complete.")
     logger.info(
         "Single state pipeline complete "
         f"for state {state} with "

--- a/nssp_demo/forecast_state.py
+++ b/nssp_demo/forecast_state.py
@@ -172,6 +172,7 @@ def main(
         param_estimates=param_estimates,
         model_batch_dir=model_batch_dir,
         logger=logger,
+        mode="forecast",
     )
     logger.info("Data preparation complete.")
 

--- a/nssp_demo/postprocess_state_forecast.R
+++ b/nssp_demo/postprocess_state_forecast.R
@@ -141,7 +141,7 @@ make_forecast_figs <- function(model_run_dir,
     pluck(1) |>
     tail(1)
 
-  data_path <- path(model_run_dir, "data", ext = "csv")
+  data_path <- path(model_run_dir, "eval_data", ext = "tsv")
   inference_data_path <- path(model_run_dir, "inference_data",
     ext = "csv"
   )

--- a/nssp_demo/prep_data.py
+++ b/nssp_demo/prep_data.py
@@ -148,11 +148,6 @@ def process_and_save_state(
     facility_level_nssp_data: pl.LazyFrame = None,
     state_level_nssp_data: pl.LazyFrame = None,
 ) -> None:
-    if mode not in ["forecast", "eval"]:
-        raise ValueError(
-            f"Invalid mode: {mode}. Mode must be 'forecast' or 'eval'."
-        )
-
     if facility_level_nssp_data is None and state_level_nssp_data is None:
         raise ValueError(
             "Must provide at least one "

--- a/nssp_demo/prep_eval_data.py
+++ b/nssp_demo/prep_eval_data.py
@@ -1,0 +1,5 @@
+import json
+import os
+from pathlib import Path
+
+import polars as pl

--- a/nssp_demo/prep_eval_data.py
+++ b/nssp_demo/prep_eval_data.py
@@ -1,5 +1,0 @@
-import json
-import os
-from pathlib import Path
-
-import polars as pl


### PR DESCRIPTION
This PR

- [x] Separates the creation of training data and evaluation data
- [x] Creates `eval_state.py`, an analogous script to `forecast_state.py`, to be used for scoring with new data.

To do:
- [ ] Verify `setup_job.py` and `forecast_state.py` still work.
- [ ] Verify post-processing R code works with new file name: `data.csv -> eval_data.tsv`
- [ ] Create new `setup_job`-like script that runs `eval_state.py`

For later:

- [ ] add scoring to new `setup_job`-like script that runs `eval_state.py`