### PR TITLE
Draft PR: Scoring plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.bin
 *.xls
 *.xlsx
+*.rds
 
 # Documents
 *.doc

--- a/nssp_demo/postprocess_scoring.R
+++ b/nssp_demo/postprocess_scoring.R
@@ -73,7 +73,6 @@ epiweekly_scoring_plot <- function(score_table, scale = "natural") {
    epiweekly_score_fig <- score_table$quantile_scores |>
         filter(scale == !!scale) |>
         mutate(epiweek = epiweek(date), epiyear = epiyear(date)) |>
-        # summarise_scores(by = c("model", "epiweek", "epiyear")) |>
         get_pairwise_comparisons(by = c("epiweek", "epiyear"),
             baseline = "cdc_baseline") |>
         mutate(epidate = epiweek_to_date(epiweek, epiyear)) |>

--- a/nssp_demo/postprocess_scoring.R
+++ b/nssp_demo/postprocess_scoring.R
@@ -1,23 +1,7 @@
-# Load the RDS file
-score_table <- readRDS("nssp_demo/score_table.rds")
-library(dplyr)
-library(scoringutils)
-library(lubridate)
-
 script_packages <- c(
   "dplyr",
-  "tidyr",
-  "tibble",
-  "readr",
-  "stringr",
-  "fs",
-  "fable",
-  "jsonlite",
-  "argparser",
-  "arrow",
-  "glue",
-  "epipredict",
-  "epiprocess"
+  "scoringutils",
+  "lubridate"
 )
 
 ## load in packages without messages

--- a/nssp_demo/postprocess_scoring.R
+++ b/nssp_demo/postprocess_scoring.R
@@ -1,0 +1,1 @@
+#Placeholder for work

--- a/nssp_demo/postprocess_scoring.R
+++ b/nssp_demo/postprocess_scoring.R
@@ -1,1 +1,66 @@
-#Placeholder for work
+# Load the RDS file
+score_table <- readRDS("nssp_demo/score_table.rds")
+library(dplyr)
+library(scoringutils)
+library(lubridate)
+
+script_packages <- c(
+  "dplyr",
+  "tidyr",
+  "tibble",
+  "readr",
+  "stringr",
+  "fs",
+  "fable",
+  "jsonlite",
+  "argparser",
+  "arrow",
+  "glue",
+  "epipredict",
+  "epiprocess"
+)
+
+## load in packages without messages
+purrr::walk(script_packages, \(pkg) {
+  suppressPackageStartupMessages(
+    library(pkg, character.only = TRUE)
+  )
+})
+
+#' Summarise Scoring Table using quantile scores
+#'
+#' This function takes a scoring table and summarises it by calculating both
+#' relative and absolute Weighted Interval Scores (WIS) for each model.
+#' The relative WIS is computed by comparing each model to a baseline model
+#' ("cdc_baseline"), while the absolute WIS, median absolute error (MAE),
+#' and interval coverages (50% and 90%) are directly summarised from the
+#' scoring table.
+#'
+#' @param score_table A data frame containing the scoring table with quantile
+#' scores.
+#' @param scale A character string specifying the scale to filter the quantile
+#' scores. Default is "natural".
+#'
+#' @return A data frame with summarised scores for each model, including
+#' relative WIS, absolute WIS, MAE, and interval coverages (50% and 90%).
+#'
+#' @examples
+#' # Assuming `score_table` is a data frame with the necessary structure:
+#' summarised_scores <- summarised_scoring_table(score_table, scale = "natural")
+#' print(summarised_scores)
+summarised_scoring_table <- function(score_table, scale = "natural") {
+  rel_wis <- score_table$quantile_scores |>
+    filter(scale == !!scale) |>
+    get_pairwise_comparisons(baseline = "cdc_baseline") |>
+    group_by(model) |>
+    summarise(rel_wis = mean(wis_scaled_relative_skill))
+
+    abs_wis <- score_table$quantile_scores |>
+        filter(scale == !!scale) |>
+        summarise_scores(by = "model") |>
+        select(model, abs_wis = wis, mae = ae_median, interval_coverage_50,
+            interval_coverage_90)
+
+    summarised_scores <- left_join(abs_wis, rel_wis, by = "model")
+    return(summarised_scores)
+}

--- a/nssp_demo/postprocess_scoring.R
+++ b/nssp_demo/postprocess_scoring.R
@@ -73,14 +73,18 @@ epiweekly_scoring_plot <- function(score_table, scale = "natural") {
    epiweekly_score_fig <- score_table$quantile_scores |>
         filter(scale == !!scale) |>
         mutate(epiweek = epiweek(date), epiyear = epiyear(date)) |>
-        summarise_scores(by = c("model", "epiweek", "epiyear")) |>
+        # summarise_scores(by = c("model", "epiweek", "epiyear")) |>
+        get_pairwise_comparisons(by = c("epiweek", "epiyear"),
+            baseline = "cdc_baseline") |>
         mutate(epidate = epiweek_to_date(epiweek, epiyear)) |>
+        group_by(model, epidate) |>
+        summarise(wis = mean(wis_scaled_relative_skill)) |>
         as_tibble() |>
         ggplot(aes(x = epidate, y = wis, color = model)) +
         geom_line() +
         geom_point() +  # Add points to the line plot
         labs(title = "Epiweekly Scoring by Model",
              x = "Epiweek start dates",
-             y = "Weighted Interval Score (WIS)") +
+             y = "Relative Weighted Interval Score (WIS)") +
         theme_minimal()
 }


### PR DESCRIPTION
This draft PR tracks the contribution of these scoring plots/tables:

- [x] Table of model performance over season. Required columns: Model, abs WIS, rel. WIS, MAE, 50% coverage and 95% coverage.
- [x] line plot of relative WIS by each week: two curves, 1 is flat (cdc flat baseline) the other is pyrenew-hew
- [ ] Heatmap plot of relative WIS by each state over season.
- [ ] [`plot_wis`](https://epiforecasts.io/scoringutils/dev/reference/plot_wis.html) showing relative contribution of under/overprediction and dispersion for cdc flat baseline and pyrenew-hew.