### PR TITLE
Workflow for building container image

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -7,6 +7,7 @@ on:
 env:
   REGISTRY: cfaprdbatchcr.azurecr.io
   IMAGE_NAME: pyrenew-hew
+  PYRENEW_VERSION: v0.1.1
 
 jobs:
 
@@ -84,7 +85,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}
           file: ./Containerfile.dependencies
           build-args: |
-            pyrenew_version=v0.1.1
+            pyrenew_version=${{ env.PYRENEW_VERSION }}
 
   build-pipeline-image:
 

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -85,7 +85,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}
           file: ./Containerfile.dependencies
           build-args: |
-            "PYRENEW_VERSION=${{ env.PYRENEW_VERSION }}"
+            PYRENEW_VERSION=${{ env.PYRENEW_VERSION }}
 
   build-pipeline-image:
 

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -81,8 +81,10 @@ jobs:
           push: true
           no-cache: true
           tags: |
-            ${{ env.REGISTRY}}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}
           file: ./Containerfile.dependencies
+          build-args: |
+            pyrenew_version=v0.1.1
 
   build-pipeline-image:
 

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -85,7 +85,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}
           file: ./Containerfile.dependencies
           build-args: |
-            PYRENEW_VERSION=${{ env.PYRENEW_VERSION }}
+            "PYRENEW_VERSION=${{ env.PYRENEW_VERSION }}"
 
   build-pipeline-image:
 

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
 
   build-dependencies-image:
-    runs-on: ubuntu-latest
+    runs-on: cfa-cdcgov
     name: Build dependencies image
 
     outputs:
@@ -89,7 +89,7 @@ jobs:
     name: Build pipeline image
 
     needs: build-dependencies-image
-    runs-on: ubuntu-latest
+    runs-on: cfa-cdcgov
 
     outputs:
       tag: ${{ needs.build-dependencies-image.outputs.tag }}

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -1,0 +1,116 @@
+name: Create Docker Image
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: cfaprdbatchcr.azurecr.io
+  IMAGE_NAME: pyrenew-hew
+
+jobs:
+
+  build-dependencies-image:
+    runs-on: ubuntu-latest
+    name: Build dependencies image
+
+    outputs:
+      tag: ${{ steps.image-tag.outputs.tag }}
+      commit-msg: ${{ steps.commit-message.outputs.message }}
+
+    steps:
+
+      #########################################################################
+      # Retrieving the commit message
+      # We need to ensure we are checking out the commit sha that triggered the
+      # workflow, not the PR's head sha. This is because the PR's head sha may
+      # be a merge commit, which will not have the commit message we need.
+      #########################################################################
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Getting the commit message
+        id: commit-message
+        run: echo "message=$(git log -1 --pretty=%s HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Checking out the latest (may be merge if PR)
+        uses: actions/checkout@v4
+
+      # From: https://stackoverflow.com/a/58035262/2097171
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: branch-name
+
+      #########################################################################
+      # Getting the tag
+      # The tag will be used for both the docker image and the batch pool
+      #########################################################################
+      - name: Figure out tag (either latest if it is main or the branch name)
+        id: image-tag
+        run: |
+          if [ "${{ steps.branch-name.outputs.branch }}" = "main" ]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ steps.branch-name.outputs.branch }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check cache for base image
+        uses: actions/cache@v4
+        id: cache
+        with:
+          key: docker-dependencies-${{ runner.os }}-${{ hashFiles('./Containerfile.dependencies') }}-${{ steps.image-tag.outputs.tag }}
+          lookup-only: true
+          path:
+            ./Containerfile.dependencies
+
+      - name: Login to the Container Registry
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: "cfaprdbatchcr.azurecr.io"
+          username: "cfaprdbatchcr"
+          password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
+
+      - name: Build and push
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          no-cache: true
+          tags: |
+            ${{ env.REGISTRY}}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}
+          file: ./Containerfile.dependencies
+
+  build-pipeline-image:
+
+    name: Build pipeline image
+
+    needs: build-dependencies-image
+    runs-on: ubuntu-latest
+
+    outputs:
+      tag: ${{ needs.build-dependencies-image.outputs.tag }}
+      commit-msg: ${{ needs.build-dependencies-image.outputs.commit-msg }}
+
+    steps:
+
+      - name: Login to the Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: "cfaprdbatchcr.azurecr.io"
+          username: "cfaprdbatchcr"
+          password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
+
+      - name: Build and push model pipeline image for Azure batch
+        id: build_and_push_model_image
+        uses: docker/build-push-action@v6
+        with:
+          push: true # This can be toggled manually for tweaking.
+          tags: |
+            ${{ env.REGISTRY}}/${{ env.IMAGE_NAME }}:${{ needs.build-dependencies-image.outputs.tag }}
+          file: ./Containerfile
+          build-args: |
+            TAG=${{ needs.build-dependencies-image.outputs.tag }}

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -85,7 +85,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}
           file: ./Containerfile.dependencies
           build-args: |
-            pyrenew_version=${{ env.PYRENEW_VERSION }}
+            PYRENEW_VERSION=${{ env.PYRENEW_VERSION }}
 
   build-pipeline-image:
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,10 +1,7 @@
-FROM python:3.12
+ARG TAG=local
 
-RUN apt-get update
-RUN apt-get install -y r-base
-RUN apt-get install -y cmake
-RUN pip install --root-user-action=ignore -U pip
-RUN pip install --root-user-action=ignore git+https://github.com/cdcgov/pyrenew
+FROM cfaprdbatchcr.azurecr.io/pyrenew-hew-dependencies:${TAG}
+
 COPY ./hewr ./pyrenew-hew/hewr
 
 WORKDIR pyrenew-hew

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.13
 
 ARG PYRENEW_VERSION=v0.1.1
 

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -1,12 +1,11 @@
-ARG PYRENEW_VERSION=v0.1.1
-
 FROM python:3.12
+
+ARG PYRENEW_VERSION=v0.1.1
 
 RUN apt-get update
 RUN apt-get install -y r-base
 RUN apt-get install -y cmake
 RUN pip install --root-user-action=ignore -U pip
-RUN echo "Pyrenew version: ${PYRENEW_VERSION}"
-RUN pip install --root-user-action=ignore git+https://github.com/cdcgov/pyrenew.git@${PYRENEW_VERSION}
+RUN pip install --root-user-action=ignore git+https://github.com/cdcgov/pyrenew.git@$PYRENEW_VERSION
 
 CMD ["bash"]

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -6,6 +6,7 @@ RUN apt-get update
 RUN apt-get install -y r-base
 RUN apt-get install -y cmake
 RUN pip install --root-user-action=ignore -U pip
+RUN echo "Pyrenew version: ${PYRENEW_VERSION}"
 RUN pip install --root-user-action=ignore git+https://github.com/cdcgov/pyrenew.git@${PYRENEW_VERSION}
 
 CMD ["bash"]

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -4,5 +4,6 @@ RUN apt-get update
 RUN apt-get install -y r-base
 RUN apt-get install -y cmake
 RUN pip install --root-user-action=ignore -U pip
+RUN pip install --root-user-action=ignore git+https://github.com/cdcgov/pyrenew
 
 CMD ["bash"]

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -1,3 +1,5 @@
+ARG pyrenew_version=v0.1.1
+
 FROM python:3.13
 
 RUN apt-get update
@@ -5,6 +7,6 @@ RUN apt-get install -y r-base
 RUN apt-get install -y cmake
 RUN pip install --root-user-action=ignore -U pip
 RUN pip install --root-user-action=ignore \
-    git+https://github.com/cdcgov/pyrenew.git@v0.1.1
+    git+https://github.com/cdcgov/pyrenew.git@${pyrenew_version}
 
 CMD ["bash"]

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -1,0 +1,8 @@
+FROM python:3.12
+
+RUN apt-get update
+RUN apt-get install -y r-base
+RUN apt-get install -y cmake
+RUN pip install --root-user-action=ignore -U pip
+
+CMD ["bash"]

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -4,6 +4,7 @@ RUN apt-get update
 RUN apt-get install -y r-base
 RUN apt-get install -y cmake
 RUN pip install --root-user-action=ignore -U pip
-RUN pip install --root-user-action=ignore git+https://github.com/cdcgov/pyrenew
+RUN pip install --root-user-action=ignore \
+    git+https://github.com/cdcgov/pyrenew.git@v0.1.1
 
 CMD ["bash"]

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -6,7 +6,6 @@ RUN apt-get update
 RUN apt-get install -y r-base
 RUN apt-get install -y cmake
 RUN pip install --root-user-action=ignore -U pip
-RUN pip install --root-user-action=ignore \
-    git+https://github.com/cdcgov/pyrenew.git@${PYRENEW_VERSION}
+RUN pip install --root-user-action=ignore git+https://github.com/cdcgov/pyrenew.git@${PYRENEW_VERSION}
 
 CMD ["bash"]

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.13
 
 RUN apt-get update
 RUN apt-get install -y r-base

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -1,4 +1,4 @@
-ARG pyrenew_version=v0.1.1
+ARG PYRENEW_VERSION=v0.1.1
 
 FROM python:3.12
 
@@ -7,6 +7,6 @@ RUN apt-get install -y r-base
 RUN apt-get install -y cmake
 RUN pip install --root-user-action=ignore -U pip
 RUN pip install --root-user-action=ignore \
-    git+https://github.com/cdcgov/pyrenew.git@${pyrenew_version}
+    git+https://github.com/cdcgov/pyrenew.git@${PYRENEW_VERSION}
 
 CMD ["bash"]

--- a/nssp_demo/prep_data.py
+++ b/nssp_demo/prep_data.py
@@ -177,9 +177,8 @@ def process_and_save_state(
         )
         .with_columns(
             # get estimate from nearest the report date
-            diff_from_report=pl.col("reference_date") - report_date
+            diff_from_report=(pl.col("reference_date") - report_date).abs()
         )
-        .abs()
         .filter(pl.col("diff_from_report") == pl.col("diff_from_report").min())
         .collect()
         .get_column("value")


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building Docker images and refactors the Dockerfiles to separate dependencies from the main application. The key changes include the creation of a workflow file, modifications to the `Containerfile`, and the addition of a new `Containerfile.dependencies`.

### Workflow and Dockerfile changes:

* **New GitHub Actions workflow**:
  * Added `.github/workflows/containers.yaml` to automate the building and pushing of Docker images. This workflow includes steps to checkout code, retrieve commit messages, determine branch names, and handle Docker caching and login.

* **Refactoring Dockerfiles**:
  * Modified `Containerfile` to use a pre-built dependencies image from the container registry, allowing for faster builds and better separation of concerns.
  * Added a new `Containerfile.dependencies` to define the base image with all necessary dependencies, including Python, R, and CMake installations.

> [!IMPORTANT]
> This depends on the `cfa-cdcgov` runners, which are currently not set for this repository. If you don't want to depend on the cdcgov runner (for now), we can change this to use ghcr.io instead. 