### PR TITLE
Adding build on push to main

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -1,6 +1,8 @@
 name: Create Docker Image
 
 on:
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
This pull request includes a small change to the GitHub Actions workflow configuration. The change ensures that Docker images are created when there is a push to the `main` branch.

* [`.github/workflows/containers.yaml`](diffhunk://#diff-a420d9d2d9925b06d0285c2c9bd4f4ad71dcca8f946d5e5b43f354ed2b938e79R4-R5): Added a `push` event trigger for the `main` branch to initiate Docker image creation.