### PR TITLE
Issue 127: add offset to ts models

### DIFF
--- a/pipelines/timeseries_forecasts.R
+++ b/pipelines/timeseries_forecasts.R
@@ -71,14 +71,20 @@ fit_and_forecast <- function(data,
   forecast_horizon <- glue::glue("{n_forecast_days} days")
   target_sym <- rlang::sym(target_col)
   output_sym <- rlang::sym(output_col)
+
+  max_visits <- data |>
+    pull(!!target_sym) |>
+    max(na.rm = TRUE)
+  offset <- 1 / max_visits
+
   fit <-
     data |>
     as_tsibble(index = date) |>
     filter(data_type == "train") |>
     model(
       comb_model = combination_ensemble(
-        ETS(log(!!target_sym) ~ trend(method = c("N", "M", "A"))),
-        ARIMA(log(!!target_sym))
+        ETS(log(!!target_sym + offset) ~ trend(method = c("N", "M", "A"))),
+        ARIMA(log(!!target_sym + offset))
       )
     )
 


### PR DESCRIPTION
This PR closes #127.

@damonbayer  identified that the problem with `NA` forecast output was occurring in numerator forecasts when the data hit zero due to `log` transform.

I've added an offset following identical pattern (1 / max observed to symmetrise in log domain) to elsewhere in this repo.