### PR TITLE
Script to run small version of prod pipeline with current branch

### DIFF
--- a/pipelines/batch/setup_pool.py
+++ b/pipelines/batch/setup_pool.py
@@ -40,6 +40,7 @@ def main(pool_name: str) -> None:
             "prod-param-estimates",
             "pyrenew-hew-prod-output",
             "pyrenew-hew-config",
+            "pyrenew-test-output",
         ],
         account_names=creds.azure_blob_storage_account,
         identity_references=node_id_ref,

--- a/pipelines/batch/setup_prod_job.py
+++ b/pipelines/batch/setup_prod_job.py
@@ -152,7 +152,7 @@ def main(
 
     all_locations = [
         loc
-        for loc in locations.get_column("STUSAB").to_list()
+        for loc in locations.get_column("STUSAB").to_list() + ["US"]
         if loc not in excluded_locations
     ]
 

--- a/pipelines/batch/setup_prod_job.py
+++ b/pipelines/batch/setup_prod_job.py
@@ -82,8 +82,8 @@ def main(
     pyrenew_hew_output_container = (
         "pyrenew-test-output" if test else "pyrenew-hew-prod-output"
     )
-    n_warmup = 10 if test else 1000
-    n_samples = 10 if test else 500
+    n_warmup = 200 if test else 1000
+    n_samples = 200 if test else 500
 
     creds = EnvCredentialHandler()
     client = get_batch_service_client(creds)

--- a/pipelines/batch/setup_prod_job.py
+++ b/pipelines/batch/setup_prod_job.py
@@ -32,6 +32,7 @@ def main(
         "VI",
         "WY",
     ],
+    test: bool = False,
 ) -> None:
     """
     job_id
@@ -78,6 +79,10 @@ def main(
             f"supported diseases are: {', '.join(supported_diseases)}"
         )
 
+    if test:
+        pyrenew_hew_output_container = "pyrenew-hew-test-output"
+    else:
+        pyrenew_hew_output_container = "pyrenew-hew-prod-output"
     creds = EnvCredentialHandler()
     client = get_batch_service_client(creds)
     job = models.JobAddParameter(
@@ -108,7 +113,7 @@ def main(
                 "target": "/pyrenew-hew/params",
             },
             {
-                "source": "pyrenew-hew-prod-output",
+                "source": pyrenew_hew_output_container,
                 "target": "/pyrenew-hew/output",
             },
             {

--- a/pipelines/batch/setup_prod_job.py
+++ b/pipelines/batch/setup_prod_job.py
@@ -131,8 +131,8 @@ def main(
         "--disease {disease} "
         "--state {state} "
         "--n-training-days 75 "
-        f"--n-warmup {n_warmup} "
-        f"--n-samples 500 {n_samples} "
+        "--n-warmup {n_warmup} "
+        "--n-samples {n_samples} "
         "--facility-level-nssp-data-dir nssp-etl/gold "
         "--state-level-nssp-data-dir "
         "nssp-archival-vintages/gold "
@@ -165,6 +165,8 @@ def main(
                 state=state,
                 disease=disease,
                 report_date="latest",
+                n_warmup=n_warmup,
+                n_samples=n_samples,
             ),
             container_settings=container_settings,
         )

--- a/pipelines/batch/setup_prod_job.py
+++ b/pipelines/batch/setup_prod_job.py
@@ -79,10 +79,12 @@ def main(
             f"supported diseases are: {', '.join(supported_diseases)}"
         )
 
-    if test:
-        pyrenew_hew_output_container = "pyrenew-test-output"
-    else:
-        pyrenew_hew_output_container = "pyrenew-hew-prod-output"
+    pyrenew_hew_output_container = (
+        "pyrenew-test-output" if test else "pyrenew-hew-prod-output"
+    )
+    n_warmup = 10 if test else 1000
+    n_samples = 10 if test else 500
+
     creds = EnvCredentialHandler()
     client = get_batch_service_client(creds)
     job = models.JobAddParameter(
@@ -129,8 +131,8 @@ def main(
         "--disease {disease} "
         "--state {state} "
         "--n-training-days 75 "
-        "--n-warmup 1000 "
-        "--n-samples 500 "
+        f"--n-warmup {n_warmup} "
+        f"--n-samples 500 {n_samples} "
         "--facility-level-nssp-data-dir nssp-etl/gold "
         "--state-level-nssp-data-dir "
         "nssp-archival-vintages/gold "

--- a/pipelines/batch/setup_prod_job.py
+++ b/pipelines/batch/setup_prod_job.py
@@ -80,7 +80,7 @@ def main(
         )
 
     if test:
-        pyrenew_hew_output_container = "pyrenew-hew-test-output"
+        pyrenew_hew_output_container = "pyrenew-test-output"
     else:
         pyrenew_hew_output_container = "pyrenew-hew-prod-output"
     creds = EnvCredentialHandler()

--- a/pipelines/batch/setup_prod_job.py
+++ b/pipelines/batch/setup_prod_job.py
@@ -150,11 +150,11 @@ def main(
         "https://www2.census.gov/geo/docs/reference/state.txt", separator="|"
     )
 
-    all_locations = (
-        locations.filter(~pl.col("STUSAB").is_in(excluded_locations))
-        .get_column("STUSAB")
-        .to_list()
-    ) + ["US"]
+    all_locations = [
+        loc
+        for loc in locations.get_column("STUSAB").to_list()
+        if loc not in excluded_locations
+    ]
 
     for disease, state in itertools.product(disease_list, all_locations):
         task = get_task_config(

--- a/pipelines/batch/setup_test_prod_job.py
+++ b/pipelines/batch/setup_test_prod_job.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
         "WV",
     ]
     main(
-        job_id=current_datetime,
+        job_id=f"pyrenew-hew-test-{current_datetime}",
         pool_id="pyrenew-pool",
         diseases=["COVID-19", "Influenza"],
         container_image_name="pyrenew-hew",

--- a/pipelines/batch/setup_test_prod_job.py
+++ b/pipelines/batch/setup_test_prod_job.py
@@ -1,0 +1,81 @@
+"""
+Set up a multi-location, multi-date,
+potentially multi-disease end to end
+retrospective evaluation run for pyrenew-hew
+on Azure Batch.
+"""
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pygit2 import Repository
+from setup_prod_job import main
+
+if __name__ == "__main__":
+    current_datetime = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%SZ")
+    current_branch = Path(Repository(os.getcwd()).head.name).stem
+    locs_to_exclude = [  # keep CA, MN, SD
+        "AS",
+        "GU",
+        "MO",
+        "MP",
+        "PR",
+        "UM",
+        "VI",
+        "WY",
+        "AK",
+        "AL",
+        "AR",
+        "AZ",
+        "CO",
+        "CT",
+        "DC",
+        "DE",
+        "FL",
+        "GA",
+        "HI",
+        "IA",
+        "ID",
+        "IL",
+        "IN",
+        "KS",
+        "KY",
+        "LA",
+        "MA",
+        "MD",
+        "ME",
+        "MI",
+        "MS",
+        "MT",
+        "NC",
+        "ND",
+        "NE",
+        "NH",
+        "NJ",
+        "NM",
+        "NV",
+        "NY",
+        "OH",
+        "OK",
+        "OR",
+        "PA",
+        "RI",
+        "SC",
+        "TN",
+        "TX",
+        "UT",
+        "VA",
+        "VT",
+        "WA",
+        "WI",
+        "WV",
+    ]
+    main(
+        job_id=current_datetime,
+        pool_id="pyrenew-pool",
+        diseases=["COVID-19", "Influenza"],
+        container_image_name="pyrenew-hew",
+        container_image_version=current_branch,
+        excluded_locations=locs_to_exclude,
+    )

--- a/pipelines/batch/setup_test_prod_job.py
+++ b/pipelines/batch/setup_test_prod_job.py
@@ -15,7 +15,7 @@ from setup_prod_job import main
 if __name__ == "__main__":
     current_datetime = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%SZ")
     current_branch = Path(Repository(os.getcwd()).head.name).stem
-    locs_to_exclude = [  # keep CA, MN, SD
+    locs_to_exclude = [  # keep CA, MN, SD, and US
         "AS",
         "GU",
         "MO",

--- a/pipelines/batch/setup_test_prod_job.py
+++ b/pipelines/batch/setup_test_prod_job.py
@@ -5,6 +5,7 @@ retrospective evaluation run for pyrenew-hew
 on Azure Batch.
 """
 
+import argparse
 import os
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,8 +14,23 @@ from pygit2 import Repository
 from setup_prod_job import main
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Test production pipeline on small subset of locations"
+    )
+    parser.add_argument(
+        "tag",
+        type=str,
+        help="The tag name to use for the container image version",
+        default=Path(Repository(os.getcwd()).head.name).stem,
+    )
+
+    args = parser.parse_args()
+
+    tag = args.tag
+    print(f"Using tag {tag}")
     current_datetime = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%SZ")
-    current_branch = Path(Repository(os.getcwd()).head.name).stem
+    tag = Path(Repository(os.getcwd()).head.name).stem
+
     locs_to_exclude = [  # keep CA, MN, SD, and US
         "AS",
         "GU",
@@ -76,7 +92,7 @@ if __name__ == "__main__":
         pool_id="pyrenew-pool",
         diseases=["COVID-19", "Influenza"],
         container_image_name="pyrenew-hew",
-        container_image_version=current_branch,
+        container_image_version=tag,
         excluded_locations=locs_to_exclude,
         test=True,
     )

--- a/pipelines/batch/setup_test_prod_job.py
+++ b/pipelines/batch/setup_test_prod_job.py
@@ -78,4 +78,5 @@ if __name__ == "__main__":
         container_image_name="pyrenew-hew",
         container_image_version=current_branch,
         excluded_locations=locs_to_exclude,
+        test=True,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ ipykernel = "^6.29.5"
 polars = "^1.5.0"
 pypdf = "^5.1.0"
 pyarrow = "^18.0.0"
+pygit2 = "^1.16.0"
 
 [tool.poetry.group.azurebatch.dependencies]
 azuretools = {git = "https://github.com/cdcent/cfa-stf-azuretools"}


### PR DESCRIPTION
Adds `test` argument to `main` function in `pipelines/batch/setup_prod_job.py`
This argument changes the default mcmc draws number, the locations processed, and storage for results.

This is then used in `pipelines/batch/setup_test_prod_job.py`, which runs the above function with `test=True` using the `pyrenew` container with tag of the current github branch, which is automatically created when that branch has an open PR.