### PR TITLE
Issue 137: unify argument patterns

### DIFF
--- a/pipelines/build_model.py
+++ b/pipelines/build_model.py
@@ -48,7 +48,7 @@ def build_model_from_dir(model_dir):
         - 1
     )
 
-    priors = runpy.run_path(prior_path)
+    priors = runpy.run_path(str(prior_path))
 
     right_truncation_offset = model_data["right_truncation_offset"]
 

--- a/pipelines/fit_model.py
+++ b/pipelines/fit_model.py
@@ -6,6 +6,7 @@ import jax
 import numpy as np
 from build_model import build_model_from_dir
 
+
 def fit_and_save_model(
     model_run_dir: str,
     n_warmup: int = 1000,

--- a/pipelines/fit_model.py
+++ b/pipelines/fit_model.py
@@ -6,7 +6,6 @@ import jax
 import numpy as np
 from build_model import build_model_from_dir
 
-
 def fit_and_save_model(
     model_run_dir: str,
     n_warmup: int = 1000,

--- a/pipelines/fit_model.py
+++ b/pipelines/fit_model.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         description="Fit the hospital-only wastewater model."
     )
     parser.add_argument(
-        "--model_run_dir",
+        "model_run_dir",
         type=Path,
         help=(
             "Path to a directory containing model fitting data. "

--- a/pipelines/generate_predictive.py
+++ b/pipelines/generate_predictive.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         description=("Do posterior prediction from a pyrenew-hew fit.")
     )
     parser.add_argument(
-        "model-run-dir",
+        "model_run_dir",
         type=Path,
         help=(
             "Path to a directory containing the model fitting data "

--- a/pipelines/iteration_helpers/loop_fit.sh
+++ b/pipelines/iteration_helpers/loop_fit.sh
@@ -13,5 +13,5 @@ BASE_DIR="$1"
 for SUBDIR in "$BASE_DIR"/*/; do
     # Run the Python script with the current subdirectory as the model_dir argument
     echo "$SUBDIR"
-    python fit_model.py --model_run_dir "$SUBDIR"
+    python fit_model.py "$SUBDIR"
 done

--- a/pipelines/iteration_helpers/loop_generate_predictive.sh
+++ b/pipelines/iteration_helpers/loop_generate_predictive.sh
@@ -14,5 +14,5 @@ BASE_DIR="$1"
 for SUBDIR in "$BASE_DIR"/*/; do
     # Run the Python script with the current subdirectory as the model_dir argument
     echo "$SUBDIR"
-    python generate_predictive.py --model_dir "$SUBDIR" --n_forecast_points 28
+    python generate_predictive.py "$SUBDIR" --n-forecast-points 28
 done

--- a/pipelines/iteration_helpers/loop_postprocess.sh
+++ b/pipelines/iteration_helpers/loop_postprocess.sh
@@ -13,5 +13,5 @@ BASE_DIR="$1"
 for SUBDIR in "$BASE_DIR"/*/; do
     # Run the R script with the current subdirectory as the model_dir argument
     echo "$SUBDIR"
-    Rscript postprocess_state_forecast.R --model-run-dir "$SUBDIR"
+    Rscript postprocess_state_forecast.R "$SUBDIR"
 done

--- a/pipelines/score_forecast.R
+++ b/pipelines/score_forecast.R
@@ -236,7 +236,7 @@ read_and_score_location <- function(model_run_dir,
 # Create a parser
 p <- arg_parser("Score a single location forecast") |>
   add_argument(
-    "model-run-dir",
+    "model_run_dir",
     help = "Directory containing the model data and output."
   )
 


### PR DESCRIPTION
This draft PR ultimately aims to close #137.

## Lists of scripts

These are the scripts to bring into common pattern as described in #137. In this case "script" means a file that is designed to have its code executed with a combination of positional and named args.

I've restricted to scripts where there is an associated bash shell script. Other scripts have patterns like input and output, or seem to have positional `disease` arguments, and these are unchanged in this PR.

### Python scripts

- [x] `fit_model.py`
- [x] `generate_predictive.py`

### R scripts

- [x] `postprocess_state_forecast.R`
- [x] `score_forecast.R`

### Bash scripts

- [x] `loop_fit.sh`
- [x] `loop_generate_predictive.sh`
- [x] `loop_postprocess.sh`
- [x] `loop_score.sh`

## Testing

Where possible I've adapted the experimental data generation from #117 and #131 to check that scripts still run via shell script calls on test data. But only for functions in `loop_fit.sh` and `loop_generate_predictive.sh` so far.