### PR TITLE
Upgrade macos runner back to latest

### DIFF
--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         r-version: ["4.4.0", "release"]
-        os: [windows-latest, ubuntu-latest, macos-13]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on:  ${{matrix.os}}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Now that https://github.com/r-lib/actions/pull/953 has landed