### PR TITLE
Adding action for deleting image

### DIFF
--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -1,8 +1,6 @@
 name: Delete tag from container registry
 
 on:
-  pull_request:
-    types: [closed]
   delete:
 
 env:

--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -1,0 +1,39 @@
+name: Delete tag from container registry
+
+on:
+  pull_request:
+    types: [closed]
+  delete:
+
+env:
+  REGISTRY: cfaprdbatchcr.azurecr.io
+  IMAGE_NAME: pyrenew-hew
+
+jobs:
+  delete-container:
+    runs-on: cfa-cdcgov
+    name: Deleting the container
+
+    steps:
+      - name : Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: branch-name
+
+      - name: Login to the Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: "cfaprdbatchcr.azurecr.io"
+          username: "cfaprdbatchcr"
+          password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
+
+      - name: Deleting the image
+        run: |
+          az acr repository delete \
+            --name ${{ env.REGISTRY }} \
+            --image ${{ env.IMAGE_NAME }}:${{ steps.branch-name.outputs.branch}}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ and [code of conduct](https://github.com/CDCgov/template/blob/master/code-of-con
 
 Describe the purpose of your project. Add additional sections as necessary to help collaborators and potential collaborators understand and use your project.
 
+## Containers
+
+The project uses GitHub Actions for automatically building container images based on the project's [Containerfile](Containerfile) and [Containerfile.dependencies](Containerfile.dependencies) files. The images are currently hosted on Azure Container Registry and are built and pushed via the [containers.yaml](.github/workflows/containers.yaml) GitHub Actions workflow.
+
+Container images pushed to the Azure Container Registry are automatically tagged as either `latest` (if the commit is on the `main` branch) or with the branch name (if the commit is on a different branch). After a branch is merged or deleted, the image tag is remove from the registry via the [delete-container-tag.yaml](.github/workflows/delete-container-tag.yaml) GitHub Actions workflow.
+
 ## Project Admin
 
 Name, Degrees, e-mail, CDC org (e.g., CDC/IOD/ORR/CFA)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Describe the purpose of your project. Add additional sections as necessary to he
 
 The project uses GitHub Actions for automatically building container images based on the project's [Containerfile](Containerfile) and [Containerfile.dependencies](Containerfile.dependencies) files. The images are currently hosted on Azure Container Registry and are built and pushed via the [containers.yaml](.github/workflows/containers.yaml) GitHub Actions workflow.
 
-Container images pushed to the Azure Container Registry are automatically tagged as either `latest` (if the commit is on the `main` branch) or with the branch name (if the commit is on a different branch). After a branch is merged or deleted, the image tag is remove from the registry via the [delete-container-tag.yaml](.github/workflows/delete-container-tag.yaml) GitHub Actions workflow.
+Container images pushed to the Azure Container Registry are automatically tagged as either `latest` (if the commit is on the `main` branch) or with the branch name (if the commit is on a different branch). After a branch is deleted, the image tag is remove from the registry via the [delete-container-tag.yaml](.github/workflows/delete-container-tag.yaml) GitHub Actions workflow.
 
 ## Project Admin
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deleting container tags from the Azure Container Registry when a pull request is closed. Additionally, it updates the `README.md` file to document the use of containers in the project.

New GitHub Actions workflow:

* [`.github/workflows/delete-container-tag.yaml`](diffhunk://#diff-5d41f68a88061c49f4d2b5b87b46ffdc4621806ca0e57829d75f5129b627c5e4R1-R39): Added a workflow to delete container tags from the Azure Container Registry upon pull request closure. This includes steps for checking out the code, extracting the branch name, logging into the container registry, and deleting the image tag.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R41-R46): Added a new section to document the use of GitHub Actions for building and managing container images. This includes details on how images are tagged and the new workflow for deleting tags.