### PR TITLE
Adding a help to the makefile and default values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,45 @@
-.PHONY: container_build container_tag acr_login container_push dep_container_build dep_container_tag
+.PHONY: help container_build container_tag acr_login container_push dep_container_build dep_container_tag dep_container_push
 
-ENGINE := docker
-DEP_CONTAINER_NAME := pyrenew-hew-dependencies
-DEP_CONTAINERFILE := Containerfile.dependencies
-DEP_CONTAINER_REMOTE_NAME := $(ACR_TAG_PREFIX)$(DEP_CONTAINER_NAME):latest
-CONTAINER_NAME := pyrenew-hew
-CONTAINERFILE := Containerfile
-CONTAINER_REMOTE_NAME := $(ACR_TAG_PREFIX)$(CONTAINER_NAME):latest
+ifndef ENGINE
+ENGINE = docker
+endif
+
+ifndef DEP_CONTAINER_NAME
+DEP_CONTAINER_NAME = pyrenew-hew-dependencies
+endif
+
+ifndef DEP_CONTAINERFILE
+DEP_CONTAINERFILE = Containerfile.dependencies
+endif
+
+ifndef DEP_CONTAINER_REMOTE_NAME
+DEP_CONTAINER_REMOTE_NAME = $(ACR_TAG_PREFIX)$(DEP_CONTAINER_NAME):latest
+endif
+
+ifndef CONTAINER_NAME
+CONTAINER_NAME = pyrenew-hew
+endif
+
+ifndef CONTAINERFILE
+CONTAINERFILE = Containerfile
+endif
+
+ifndef CONTAINER_REMOTE_NAME
+CONTAINER_REMOTE_NAME = $(ACR_TAG_PREFIX)$(CONTAINER_NAME):latest
+endif
+
+
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  container_build     : Build the container image"
+	@echo "  container_tag       : Tag the container image"
+	@echo "  acr_login           : Log in to the Azure Container Registry"
+	@echo "  container_push      : Push the container image to the Azure Container Registry"
+	@echo "  dep_container_build : Build the dependencies container image"
+	@echo "  dep_container_tag   : Tag the dependencies container image"
+	@echo "  dep_container_push  : Push the dependencies container image to the Azure Container Registry"
 
 dep_container_build:
 	$(ENGINE) build . -t $(DEP_CONTAINER_NAME) -f $(DEP_CONTAINERFILE)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Describe the purpose of your project. Add additional sections as necessary to he
 
 The project uses GitHub Actions for automatically building container images based on the project's [Containerfile](Containerfile) and [Containerfile.dependencies](Containerfile.dependencies) files. The images are currently hosted on Azure Container Registry and are built and pushed via the [containers.yaml](.github/workflows/containers.yaml) GitHub Actions workflow.
 
+Images can also be built locally. The [Makefile](Makefile) contains several targets for building and pushing images. Although the Makefile uses Docker as the default engine, the `ENGINE` environment variable can be set to `podman` to use Podman instead, for example:
+
+```bash
+ENGINE=podman make dep_container_build
+# Equivalent to:
+# podman build . -t pyrenew-hew-dependencies -f Containerfile.dependencies
+```
+
 Container images pushed to the Azure Container Registry are automatically tagged as either `latest` (if the commit is on the `main` branch) or with the branch name (if the commit is on a different branch). After a branch is deleted, the image tag is remove from the registry via the [delete-container-tag.yaml](.github/workflows/delete-container-tag.yaml) GitHub Actions workflow.
 
 ## Project Admin


### PR DESCRIPTION
This pull request includes several changes to the `Makefile` to improve its functionality and usability. The most important changes include adding a `help` target and using conditional assignment for variables.

Improvements to usability:

* Added a `help` target to provide usage instructions and a list of available targets.

Codebase improvements:

* Hardcoded variables are now optional. For instance, if the users wanted to build using `podman` they can run `ENGINE=podman make ...`.