### PR TITLE
Depend on `ensure_listlike` from `forecasttools`

### DIFF
--- a/pipelines/collate_plots.py
+++ b/pipelines/collate_plots.py
@@ -5,8 +5,9 @@ import logging
 import os
 from pathlib import Path
 
+from forecasttools import ensure_listlike
 from pypdf import PdfWriter
-from utils import ensure_listlike, get_all_forecast_dirs
+from utils import get_all_forecast_dirs
 
 
 def merge_pdfs_and_save(

--- a/pipelines/utils.py
+++ b/pipelines/utils.py
@@ -6,37 +6,9 @@ pipeline.
 import datetime
 import os
 import re
-from collections.abc import MutableSequence
 from pathlib import Path
 
 disease_map_lower_ = {"influenza": "Influenza", "covid-19": "COVID-19"}
-
-
-def ensure_listlike(x):
-    """
-    Ensure that an object either behaves like a
-    :class:`MutableSequence` and if not return a
-    one-item :class:`list` containing the object.
-
-    Useful for handling list-of-strings inputs
-    alongside single strings.
-
-    Based on this _`StackOverflow approach
-    <https://stackoverflow.com/a/66485952>`.
-
-    Parameters
-    ----------
-    x
-        The item to ensure is :class:`list`-like.
-
-    Returns
-    -------
-    MutableSequence
-        ``x`` if ``x`` is a :class:`MutableSequence`
-        otherwise ``[x]`` (i.e. a one-item list containing
-        ``x``.
-    """
-    return x if isinstance(x, MutableSequence) else [x]
 
 
 def parse_model_batch_dir_name(model_batch_dir_name):


### PR DESCRIPTION
Now that we depend on `forecasttools` and it provides `ensure_listlike`, we can remove it from `pipelines/utils.py`