### PR TITLE
Remove time column from output

### DIFF
--- a/hewr/R/process_state_forecast.R
+++ b/hewr/R/process_state_forecast.R
@@ -45,7 +45,6 @@ combine_training_and_eval_data <- function(train_dat,
     ) |>
     with_prop_disease_ed_visits() |>
     dplyr::select(-"Total") |>
-    dplyr::mutate(time = dplyr::dense_rank(.data$date)) |>
     tidyr::pivot_longer(
       c("Disease", "Other", "prop_disease_ed_visits"),
       names_to = "disease",

--- a/hewr/tests/testthat/test_process_state_forecast.R
+++ b/hewr/tests/testthat/test_process_state_forecast.R
@@ -47,7 +47,6 @@ test_that("combine_training_and_eval_data works as expected", {
 
     checkmate::assert_names(names(result),
       permutation.of = c(
-        "time",
         "date",
         "data_type",
         "disease",

--- a/pipelines/diagnostic_report/template.qmd
+++ b/pipelines/diagnostic_report/template.qmd
@@ -7,7 +7,7 @@ format:
     - custom.scss
     embed-resources: false
 params:
-  model_dir_raw: "/home/xum8/pyrenew-hew/private_data/pyrenew-test-output/covid-19_r_2024-11-22_f_2024-08-19_t_2024-11-16/model_runs/MN/" # pragma: allowlist-secret
+  model_dir_raw: "/Users/damon/Documents/GitHub/pyrenew-hew/pipelines/tests/private_data/covid-19_r_2024-12-21_f_2024-10-22_t_2024-12-20/model_runs/CA" # pragma: allowlist-secret
 ---
 <!-- Would like embed-resources to be true, but the current version is problematic with blobfuse -->
 
@@ -184,7 +184,8 @@ figure_save_tbl |>
 ```{r Rt Plot}
 #| title: Posterior Rt
 date_time_map <- combined_dat |>
-  distinct(time, date)
+  distinct(date) |>
+  mutate(time = dense_rank(date) - 1)
 
 last_training_date <- combined_dat |>
   dplyr::filter(data_type == "train") |>


### PR DESCRIPTION
Calling this column `time` was ill-defined and wasn't really used for anything. Caused me some confusion when working on multiple data streams.