### PR TITLE
Update delete-container-tag.yaml

### DIFF
--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -55,4 +55,4 @@ jobs:
           az acr repository delete \
             --yes \
             --name ${{ env.REGISTRY }} \
-            --image ${{ env.IMAGE_NAME }}-dependencies:${{ steps.image-tag.outputs.tag }}
+            --image ${{ env.IMAGE_NAME }}:dependencies-${{ steps.image-tag.outputs.tag }}


### PR DESCRIPTION
#302 missed updating the workflow for deleting tags. The action twostep-container-build uses `[image]:dependencies-[branch]` instead of `[image]-dependencies:[branch]`. This PR fixes it.