### PR TITLE
Cancel outdated CI workflows

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: cfaprdbatchcr.azurecr.io/
   IMAGE_NAME: pyrenew-hew

--- a/.github/workflows/pipeline-run-check.yaml
+++ b/.github/workflows/pipeline-run-check.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-pipeline:
     strategy:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-hewr:
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pyrenew-hew-test:
     name: Run pyrenew_hew tests and collect coverage


### PR DESCRIPTION
Update CI workflows that run on pushes to main and/or PRs so that in-progress runs are canceled by new commits. Saves compute resources and ensures that the latest complete run reflects the latest commit.