### PR TITLE
Improvements and bug fixes for epiweekly other hubverse tables and plots

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
   #####
   # R
   - repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.3.9001
+    rev: v0.4.3
     hooks:
       - id: style-files
       - id: lintr

--- a/hewr/R/to_epiweekly_quantile_table.R
+++ b/hewr/R/to_epiweekly_quantile_table.R
@@ -65,7 +65,8 @@ to_epiweekly_quantiles <- function(model_run_dir,
       value_col = ".value"
     ) |>
     dplyr::mutate(
-      "location" = !!location
+      "location" = !!location,
+      "source_file" = !!draws_file_name
     )
   message(glue::glue("Done processing {model_run_dir}"))
   return(epiweekly_quantiles)
@@ -124,8 +125,8 @@ to_epiweekly_quantile_table <- function(model_batch_dir,
 
   get_location_table <- \(model_run_dir) {
     loc <- fs::path_file(model_run_dir)
-    epiweekly_other <- loc %in% epiweekly_other_locations
-    if (epiweekly_other) {
+    use_epiweekly_other <- loc %in% epiweekly_other_locations
+    if (use_epiweekly_other) {
       message(glue::glue(
         "Using epiweekly non-target ED visit forecast ",
         "for location {loc}"
@@ -137,7 +138,7 @@ to_epiweekly_quantile_table <- function(model_batch_dir,
       ))
     }
     draws_file <- ifelse(
-      epiweekly_other,
+      use_epiweekly_other,
       "epiweekly_with_epiweekly_other_samples",
       "epiweekly_samples"
     )
@@ -167,12 +168,6 @@ to_epiweekly_quantile_table <- function(model_batch_dir,
       .data$reference_date,
       .data$horizon,
       .data$output_type_id
-    ) |>
-    dplyr::mutate(other_ed_visit_forecast = ifelse(
-      .data$location %in% !!epiweekly_other_locations,
-      "direct_epiweekly_fit",
-      "aggregated_daily_fit"
-    ))
-
+    )
   return(hubverse_table)
 }

--- a/hewr/R/to_epiweekly_quantile_table.R
+++ b/hewr/R/to_epiweekly_quantile_table.R
@@ -126,17 +126,15 @@ to_epiweekly_quantile_table <- function(model_batch_dir,
   get_location_table <- \(model_run_dir) {
     loc <- fs::path_file(model_run_dir)
     use_epiweekly_other <- loc %in% epiweekly_other_locations
-    if (use_epiweekly_other) {
-      message(glue::glue(
-        "Using epiweekly non-target ED visit forecast ",
-        "for location {loc}"
-      ))
-    } else {
-      message(glue::glue(
-        "Using daily non-target ED visit ",
-        "forecast for location {loc}."
-      ))
-    }
+    which_forecast <- ifelse(use_epiweekly_other,
+      "explicitly epiweekly",
+      "aggregated daily"
+    )
+    glue::glue(
+      "Using {which_forecast} non-target ED visit forecast ",
+      "for location {loc}"
+    )
+
     draws_file <- ifelse(
       use_epiweekly_other,
       "epiweekly_with_epiweekly_other_samples",

--- a/hewr/tests/testthat/test_to_epiweekly_quantile_table.R
+++ b/hewr/tests/testthat/test_to_epiweekly_quantile_table.R
@@ -181,7 +181,7 @@ test_that("to_epiweekly_quantile_table handles multiple locations", {
       "output_type",
       "output_type_id",
       "value",
-      "other_ed_visit_forecast"
+      "source_samples"
     )
   )
   expect_setequal(

--- a/hewr/tests/testthat/test_to_epiweekly_quantile_table.R
+++ b/hewr/tests/testthat/test_to_epiweekly_quantile_table.R
@@ -39,9 +39,20 @@ test_that("to_epiweekly_quantiles works as expected", {
     ) |> suppressMessages()
 
     expect_s3_class(result, "tbl_df")
-    expect_setequal(c(
-      "epiweek", "epiyear", "quantile_value", "quantile_level", "location"
-    ), colnames(result))
+    checkmate::expect_names(
+      colnames(result),
+      identical.to = c(
+        "epiweek",
+        "epiyear",
+        "quantile_value",
+        "quantile_level",
+        "location",
+        "source_samples"
+      )
+    )
+
+    expect_equal(draws_file_name, unique(result$source_samples))
+
     expect_gt(nrow(result), 0)
   }
 
@@ -127,7 +138,11 @@ test_that("to_epiweekly_quantiles handles missing forecast files", {
 
 
 # tests for `to_epiweekly_quantile_table`
-test_that("to_epiweekly_quantile_table handles multiple locations", {
+test_that(paste0(
+  "to_epiweekly_quantile_table ",
+  "handles multiple locations ",
+  "and multiple source files"
+), {
   batch_dir_name <- "covid-19_r_2024-12-14_f_2024-12-08_t_2024-12-14"
   tempdir <- withr::local_tempdir()
 
@@ -142,6 +157,17 @@ test_that("to_epiweekly_quantile_table handles multiple locations", {
     if (loc != "loc3") {
       disease_cols <- c(disease_cols, "prop_disease_ed_visits")
     }
+    create_tidy_forecast_data(
+      directory = loc_dir,
+      filename = "epiweekly_with_epiweekly_other_samples.parquet",
+      date_cols = seq(
+        lubridate::ymd("2024-12-08"), lubridate::ymd("2024-12-14"),
+        by = "week"
+      ),
+      disease_cols = disease_cols,
+      n_draw = 25,
+      with_epiweek = TRUE
+    )
 
     create_tidy_forecast_data(
       directory = loc_dir,
@@ -157,7 +183,10 @@ test_that("to_epiweekly_quantile_table handles multiple locations", {
   })
 
   ## should succeed despite loc3 not having valid draws with strict = FALSE
-  result_w_both_locations <- to_epiweekly_quantile_table(temp_batch_dir) |>
+  result_w_both_locations <-
+    to_epiweekly_quantile_table(temp_batch_dir,
+      epiweekly_other_locations = "loc1"
+    ) |>
     suppressMessages()
 
   ## should error if strict = TRUE because loc3 does not have
@@ -166,6 +195,36 @@ test_that("to_epiweekly_quantile_table handles multiple locations", {
     to_epiweekly_quantile_table(temp_batch_dir, strict = TRUE) |>
       suppressMessages(),
     "did not find valid draws"
+  )
+
+  ## should succeed with strict = TRUE if loc3 is excluded
+  alt_result_w_both_locations <- (
+    to_epiweekly_quantile_table(temp_batch_dir,
+      strict = TRUE,
+      exclude = "loc3"
+  )) |>
+    suppressMessages()
+
+  ## results should be equivalent for loc2,
+  ## but not for loc1
+  expect_equal(
+    result_w_both_locations |>
+      dplyr::filter(location == "loc2"),
+    alt_result_w_both_locations |>
+      dplyr::filter(location == "loc2")
+  )
+
+  ## check that one used epiweekly
+  ## other for loc1 while other used
+  ## default, resulting in different values
+  loc1_a <- result_w_both_locations |>
+    dplyr::filter(location == "loc1") |>
+    dplyr::pull(.data$value)
+  loc1_b <- alt_result_w_both_locations |>
+    dplyr::filter(location == "loc1") |>
+    dplyr::pull(.data$value)
+  expect_false(
+    any(loc1_a == loc1_b)
   )
 
   expect_s3_class(result_w_both_locations, "tbl_df")
@@ -185,16 +244,28 @@ test_that("to_epiweekly_quantile_table handles multiple locations", {
     )
   )
   expect_setequal(
-    c("loc1", "loc2"),
-    result_w_both_locations$location
+    result_w_both_locations$location,
+    c("loc1", "loc2")
   )
-  expect_false("loc3" %in% result_w_both_locations$location)
+  expect_setequal(
+    alt_result_w_both_locations$location,
+    c("loc1", "loc2")
+  )
 
-  result_w_one_location <- to_epiweekly_quantile_table(
-    model_batch_dir = temp_batch_dir,
-    exclude = "loc1"
-  ) |>
-    suppressMessages()
-  expect_true("loc2" %in% result_w_one_location$location)
-  expect_false("loc1" %in% result_w_one_location$location)
+  expect_setequal(
+    result_w_both_locations$source_samples,
+    c(
+      "epiweekly_samples",
+      "epiweekly_with_epiweekly_other_samples"
+    )
+  )
+
+  expect_setequal(
+    alt_result_w_both_locations$source_samples,
+    "epiweekly_samples"
+  )
+
+
+  expect_false("loc3" %in% result_w_both_locations$location)
+  expect_false("loc3" %in% alt_result_w_both_locations$location)
 })

--- a/hewr/tests/testthat/test_to_epiweekly_quantile_table.R
+++ b/hewr/tests/testthat/test_to_epiweekly_quantile_table.R
@@ -224,7 +224,10 @@ test_that(paste0(
     dplyr::filter(location == "loc1") |>
     dplyr::pull(.data$value)
 
-  ## these confirm that the subsequent test is valid
+  ## length checks ensure that the
+  ## number of allowed equalities _could_
+  ## be reached if the vectors were mostly
+  ## or entirely identical
   expect_gt(length(loc1_a), 10)
   expect_gt(length(loc1_b), 10)
   expect_lt(

--- a/hewr/tests/testthat/test_to_epiweekly_quantile_table.R
+++ b/hewr/tests/testthat/test_to_epiweekly_quantile_table.R
@@ -223,6 +223,10 @@ test_that(paste0(
   loc1_b <- alt_result_w_both_locations |>
     dplyr::filter(location == "loc1") |>
     dplyr::pull(.data$value)
+
+  ## these confirm that the subsequent test is valid
+  expect_gt(length(loc1_a), 10)
+  expect_gt(length(loc1_b), 10)
   expect_lt(
     sum(loc1_a == loc1_b),
     5

--- a/hewr/tests/testthat/test_to_epiweekly_quantile_table.R
+++ b/hewr/tests/testthat/test_to_epiweekly_quantile_table.R
@@ -223,8 +223,9 @@ test_that(paste0(
   loc1_b <- alt_result_w_both_locations |>
     dplyr::filter(location == "loc1") |>
     dplyr::pull(.data$value)
-  expect_false(
-    any(loc1_a == loc1_b)
+  expect_lt(
+    sum(loc1_a == loc1_b),
+    5
   )
 
   expect_s3_class(result_w_both_locations, "tbl_df")

--- a/pipelines/postprocess_forecast_batches.py
+++ b/pipelines/postprocess_forecast_batches.py
@@ -64,10 +64,8 @@ def create_hubverse_table(
     )
     if result.returncode != 0:
         raise RuntimeError(
-            "create_hubverse_table: " f"{result.stdout}\n" f"{result.stderr}"
+            f"create_hubverse_table: {result.stdout}\n {result.stderr}"
         )
-    else:
-        logger.info("create_hubverse_table", result.stdout)
 
     return None
 

--- a/pipelines/postprocess_forecast_batches.py
+++ b/pipelines/postprocess_forecast_batches.py
@@ -56,9 +56,9 @@ def create_hubverse_table(
             f"{model_batch_dir_path}",
             f"{output_path}",
             "--exclude",
-            f"{locations_exclude}",
+            f"{' '.join(locations_exclude)}",
             "--epiweekly-other-locations",
-            f"{epiweekly_other_locations}",
+            f"{' '.join(epiweekly_other_locations)}",
         ],
         capture_output=True,
     )

--- a/pipelines/postprocess_forecast_batches.py
+++ b/pipelines/postprocess_forecast_batches.py
@@ -125,6 +125,9 @@ def process_model_batch_dir(
     logger.info("Collating plots...")
     cp.process_dir(model_batch_dir_path, target_filenames=plots_to_collate)
     logger.info("Creating hubverse table...")
+    logger.info(
+        "Using epiweekly other forecast for " f"{epiweekly_other_locations}..."
+    )
     create_hubverse_table(
         model_batch_dir_path,
         locations_exclude=locations_exclude,

--- a/pipelines/postprocess_forecast_batches.py
+++ b/pipelines/postprocess_forecast_batches.py
@@ -34,6 +34,8 @@ def create_hubverse_table(
     locations_exclude: str | list[str] = "",
     epiweekly_other_locations: str | list[str] = "",
 ) -> None:
+    logger = logging.getLogger(__name__)
+
     locations_exclude = ensure_listlike(locations_exclude)
     epiweekly_other_locations = ensure_listlike(epiweekly_other_locations)
 
@@ -64,6 +66,9 @@ def create_hubverse_table(
         raise RuntimeError(
             "create_hubverse_table: " f"{result.stdout}\n" f"{result.stderr}"
         )
+    else:
+        logger.info("create_hubverse_table", result.stdout)
+
     return None
 
 


### PR DESCRIPTION
- Fixes bug (incorrect mixing of full paths with base location names) that caused requests to use the epiweekly other ED visit forecast to get ignored
- Makes it possible to specify a list of locations for which to use the epiweekly other forecast in `postprocess_forecast_batches.py`
- Includes epiweekly other plots in plot collation
- Adds tests that would have caught the bug