### PR TITLE
Streamline tag delete

### DIFF
--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -1,17 +1,17 @@
-name: Delete tag from container registry
+name: Delete branch tag from container registry
 
 on:
   delete:
 
 env:
-  REGISTRY: cfaprdbatchcr.azurecr.io
+  REGISTRY: ${{ vars.CONTAINER_REGISTRY }}
   IMAGE_NAME: pyrenew-hew
 
 jobs:
   delete-container:
     if: github.event.ref_type == 'branch'
     runs-on: cfa-cdcgov
-    name: Deleting the container
+    name: Delete tag 
 
     steps:
       - name : Checkout code
@@ -27,20 +27,10 @@ jobs:
             echo "tag=${{ github.event.ref }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Login to the Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: "cfaprdbatchcr.azurecr.io"
-          username: "cfaprdbatchcr"
-          password: ${{ secrets.CFAPRDBATCHCR_REGISTRY_PASSWORD }}
-
-      - name: Login to Azure with NNH Service Principal
+      - name: Login to Azure
         id: azure_login_2
         uses: azure/login@v2
         with:
-          # managed by EDAV. Contact Amit Mantri or Jon Kislin if you
-          # have issues. Also, this is documented in the Predict
-          # handbook.
           creds: ${{ secrets.EDAV_STF_SERVICE_PRINCIPAL }}
 
       - name: Deleting the image

--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -11,7 +11,7 @@ jobs:
   delete-container:
     if: github.event.ref_type == 'branch'
     runs-on: cfa-cdcgov
-    name: Delete tag 
+    name: Delete tag
 
     steps:
       - name : Checkout code


### PR DESCRIPTION
Docker login not needed since we log in directly to Azure and use `az`. This will also make #321 rarer (though there we might still have problems with two build/push workflows running simultaneously)