### PR TITLE
Add .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+
+exclude_lines =
+    if __name__ == .__main__.:

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -5,9 +5,8 @@ ARG PYRENEW_VERSION="v0.1.2"
 RUN apt-get update
 RUN apt-get install -y r-base
 RUN apt-get install -y cmake
-RUN echo $PYRENW_VERSION
 RUN pip install --root-user-action=ignore -U pip
-RUN pip install --root-user-action=ignore 'git+https://github.com/cdcgov/pyrenew.git@'$PYRENEW_VERSION
+RUN pip install --root-user-action=ignore git+https://github.com/cdcgov/pyrenew.git@$PYRENEW_VERSION
 RUN pip install --root-user-action=ignore quarto-cli
 
 CMD ["bash"]

--- a/Containerfile.dependencies
+++ b/Containerfile.dependencies
@@ -5,8 +5,9 @@ ARG PYRENEW_VERSION="v0.1.2"
 RUN apt-get update
 RUN apt-get install -y r-base
 RUN apt-get install -y cmake
+RUN echo $PYRENW_VERSION
 RUN pip install --root-user-action=ignore -U pip
-RUN pip install --root-user-action=ignore git+https://github.com/cdcgov/pyrenew.git@$PYRENEW_VERSION
+RUN pip install --root-user-action=ignore 'git+https://github.com/cdcgov/pyrenew.git@'$PYRENEW_VERSION
 RUN pip install --root-user-action=ignore quarto-cli
 
 CMD ["bash"]


### PR DESCRIPTION
This will allow us to exclude blocks for which we do not write explicit tests (e.g. `if __name__ == "__main__":` sections) from coverage reports.