### PR TITLE
Fix failing CI by applying epipredict patch

### DIFF
--- a/.github/workflows/pipeline-run-check.yaml
+++ b/.github/workflows/pipeline-run-check.yaml
@@ -40,11 +40,8 @@ jobs:
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           working-directory: hewr
-      - name: "Install extra pkgs"
-        run: |
-            pak::local_install("hewr", ask = FALSE)
-            pak::pkg_install("cmu-delphi/epipredict@main", ask = FALSE)
-            pak::pkg_install("cmu-delphi/epiprocess@main", ask = FALSE)
+      - name: "Install hewr"
+        run: pak::local_install("hewr", ask = FALSE)
         shell: Rscript {0}
       - name: "Run pipeline"
         run: poetry run bash pipelines/tests/test_end_to_end.sh pipelines/tests

--- a/hewr/DESCRIPTION
+++ b/hewr/DESCRIPTION
@@ -42,9 +42,13 @@ Imports:
     tidybayes,
     tidyr,
     tidyselect,
+    epipredict,
+    epiprocess,
     urca
 Remotes:
-    https://github.com/cdcgov/forecasttools
+    https://github.com/cdcgov/forecasttools,
+    https://github.com/cmu-delphi/epipredict,
+    https://github.com/cmu-delphi/epiprocess
 Suggests:
     checkmate,
     rcmdcheck,


### PR DESCRIPTION
- For now, we depend on the dev version of `epipredict`. We can change this in the future
- `epipredict` and `epiprocess` are now explicit `hewr` deps (which they should've been already).
- This allows us to simplify the pipeline run check action somewhat, since they don't need to be installed separately.