### PR TITLE
Use `model_name` to set `fit_<signal>` flags for `build_model_from_dir` in `generate_predictive.py`

### DIFF
--- a/pipelines/build_pyrenew_model.py
+++ b/pipelines/build_pyrenew_model.py
@@ -18,10 +18,37 @@ from pyrenew_hew.pyrenew_hew_model import (
 
 def build_model_from_dir(
     model_dir: Path,
-    sample_ed_visits: bool = False,
-    sample_hospital_admissions: bool = False,
-    sample_wastewater: bool = False,
+    fit_ed_visits: bool = False,
+    fit_hospital_admissions: bool = False,
+    fit_wastewater: bool = False,
 ) -> tuple[PyrenewHEWModel, PyrenewHEWData]:
+    """
+    Build a pyrenew-family model from a model run directory
+    containing data (as a .json file) and priors (as a .py file)
+
+    Parameters
+    ----------
+    model_dir
+        The model directory, containing a priors file and a
+        data subdirectory.
+
+    fit_ed_visits
+        Fit ED visit data in the built model? Default ``False``.
+
+    fit_ed_visits
+        Fit hospital admissions data in the built model?
+        Default ``False``.
+
+    fit_wastewater
+        Fit wastewater pathogen genome concentration data
+        in the built model? Default ``False``.
+
+    Returns
+    -------
+    tuple[PyrenewHEWModel, PyrenewHEWData]
+        Instantiated model and data objects representing
+        the model and its fitting data, respectively.
+    """
     data_path = Path(model_dir) / "data" / "data_for_model_fit.json"
     prior_path = Path(model_dir) / "priors.py"
 
@@ -52,17 +79,17 @@ def build_model_from_dir(
 
     data_observed_disease_ed_visits = (
         jnp.array(model_data["data_observed_disease_ed_visits"])
-        if sample_ed_visits
+        if fit_ed_visits
         else None
     )
     data_observed_disease_hospital_admissions = (
         jnp.array(model_data["data_observed_disease_hospital_admissions"])
-        if sample_hospital_admissions
+        if fit_hospital_admissions
         else None
     )
 
     # placeholder
-    data_observed_disease_wastewater = None if sample_wastewater else None
+    data_observed_disease_wastewater = None if fit_wastewater else None
 
     population_size = jnp.array(model_data["state_pop"])
 

--- a/pipelines/build_pyrenew_model.py
+++ b/pipelines/build_pyrenew_model.py
@@ -94,7 +94,7 @@ def build_model_from_dir(
             model_data["data_observed_disease_wastewater"],
             schema_overrides={"date": pl.Date},
         )
-        if sample_wastewater
+        if fit_wastewater
         else None
     )
 

--- a/pipelines/fit_pyrenew_model.py
+++ b/pipelines/fit_pyrenew_model.py
@@ -31,9 +31,9 @@ def fit_and_save_model(
         )
     (my_model, my_data) = build_model_from_dir(
         model_run_dir,
-        sample_ed_visits=fit_ed_visits,
-        sample_hospital_admissions=fit_hospital_admissions,
-        sample_wastewater=fit_wastewater,
+        fit_ed_visits=fit_ed_visits,
+        fit_hospital_admissions=fit_hospital_admissions,
+        fit_wastewater=fit_wastewater,
     )
     my_model.run(
         data=my_data,

--- a/pipelines/generate_predictive.py
+++ b/pipelines/generate_predictive.py
@@ -20,11 +20,9 @@ def generate_and_save_predictions(
     model_dir = Path(model_run_dir, model_name)
     if not model_dir.exists():
         raise FileNotFoundError(f"The directory {model_dir} does not exist.")
+
     (my_model, my_data) = build_model_from_dir(
-        model_run_dir,
-        sample_ed_visits=predict_ed_visits,
-        sample_hospital_admissions=predict_hospital_admissions,
-        sample_wastewater=predict_wastewater,
+        model_run_dir, **flags_from_pyrenew_model_name(model_name)
     )
 
     my_model._init_model(1, 1)

--- a/pipelines/generate_predictive.py
+++ b/pipelines/generate_predictive.py
@@ -7,6 +7,8 @@ from build_pyrenew_model import (
     build_model_from_dir,
 )
 
+from pyrenew_hew.util import flags_from_pyrenew_model_name
+
 
 def generate_and_save_predictions(
     model_run_dir: str | Path,

--- a/pipelines/tests/test_build_pyrenew_model.py
+++ b/pipelines/tests/test_build_pyrenew_model.py
@@ -16,6 +16,9 @@ def mock_data():
             "state_pop": [7, 8, 9],
             "generation_interval_pmf": [0.1, 0.2, 0.7],
             "inf_to_ed_pmf": [0.4, 0.5, 0.1],
+            "inf_to_hosp_admit_pmf": [0.0, 0.7, 0.1, 0.1, 0.1],
+            "inf_to_hosp_admit_lognormal_loc": 0.015,
+            "inf_to_hosp_admit_lognormal_scale": 0.851,
             "right_truncation_pmf": [0.7, 0.1, 0.2],
             "nssp_training_dates": ["2025-01-01"],
             "nhsn_training_dates": ["2025-01-02"],
@@ -44,6 +47,8 @@ hosp_admit_neg_bin_concentration_rv = None
 ihr_rv = None
 t_peak_rv = None
 duration_shed_after_peak_rv = None
+inf_to_ed_offset_loc_rv = None
+inf_to_ed_log_offset_scale_rv = None
 log10_genome_per_inf_ind_rv = None
 mode_sigma_ww_site_rv = None
 sd_log_sigma_ww_site_rv = None
@@ -65,18 +70,18 @@ def test_build_model_from_dir(tmp_path, mock_data, mock_priors):
 
     model_data = json.loads(mock_data)
 
-    # Test when all sample arguments are False
+    # Test when all `fit_` arguments are False
     _, data = build_model_from_dir(model_dir)
     assert data.data_observed_disease_ed_visits is None
     assert data.data_observed_disease_hospital_admissions is None
     assert data.data_observed_disease_wastewater is None
 
-    # Test when all sample arguments are True
+    # Test when all `fit_` arguments are True
     _, data = build_model_from_dir(
         model_dir,
-        sample_ed_visits=True,
-        sample_hospital_admissions=True,
-        sample_wastewater=True,
+        fit_ed_visits=True,
+        fit_hospital_admissions=True,
+        fit_wastewater=True,
     )
     assert jnp.array_equal(
         data.data_observed_disease_ed_visits,

--- a/pyrenew_hew/util.py
+++ b/pyrenew_hew/util.py
@@ -45,27 +45,27 @@ def hew_letters_from_flags(
     fit_wastewater: bool = False,
 ) -> str:
     """
-        Get the {h, e, w} letters defining
-        a model from a set of flags indicating which
-        of the datastreams, if any, were used in fitting.
-        If none of them were, return the string "null"
+    Get the {h, e, w} letters defining
+    a model from a set of flags indicating which
+    of the datastreams, if any, were used in fitting.
+    If none of them were, return the string "null"
 
-        Parameters
-        ----------
-        fit_ed_visits
-            ED visit data used in fitting?
+    Parameters
+    ----------
+    fit_ed_visits
+        ED visit data used in fitting?
 
-        fit_hospital_admissions
-            Hospital admissions data used in fitting?
+    fit_hospital_admissions
+        Hospital admissions data used in fitting?
 
-        fit_wastewater
-            Wastewater data used in fitting?
+    fit_wastewater
+        Wastewater data used in fitting?
 
-        Returns
-        -------
-        str
-            The relevant HEW letters, or 'null',
-    a"""
+    Returns
+    -------
+    str
+        The relevant HEW letters, or 'null',
+    """
     result = (
         f"{'h' if fit_hospital_admissions else ''}"
         f"{'e' if fit_ed_visits else ''}"
@@ -113,14 +113,11 @@ def flags_from_hew_letters(hew_letters: str) -> dict[str, bool]:
             "a string consisting only of the letters "
             f"in {valid_letters} or the string 'null'"
         )
-    result = dict(
+    return dict(
         fit_hospital_admissions="h" in hew_letters,
         fit_ed_visits="e" in hew_letters,
         fit_wastewater="w" in hew_letters,
     )
-    if not result:
-        result = "null"
-    return result
 
 
 def pyrenew_model_name_from_flags(

--- a/pyrenew_hew/util.py
+++ b/pyrenew_hew/util.py
@@ -104,7 +104,7 @@ def flags_from_hew_letters(hew_letters: str) -> dict[str, bool]:
         ``'h'``, ``'e'``, and ``'w'``.
     """
     valid_letters = {"h", "e", "w"}
-    letterset = set(list(hew_letters))
+    letterset = set(hew_letters)
     if not (
         hew_letters.lower() == "null" or letterset.issubset(valid_letters)
     ):

--- a/pyrenew_hew/util.py
+++ b/pyrenew_hew/util.py
@@ -76,6 +76,45 @@ def hew_letters_from_flags(
     return result
 
 
+def flags_from_hew_letters(hew_letters: str) -> dict[str, bool]:
+    """
+    Get True/False flags defining whether signals
+    were fit from the {h, e, w} letters (or 'null')
+    defining the model. Inverse of
+    :func:`hew_letters_from_flags`
+
+    Parameters
+    ----------
+    hew_letters
+        The relevant HEW letters, or 'null',
+
+    Returns
+    -------
+    dict[str, bool]
+       Dictionary with boolean entries named
+       ``fit_hospital_admissions``, ``fit_ed_visits``,
+       and ``fit_wastewater``.
+    """
+    valid_letters = {"h", "e", "w"}
+    letterset = set(list(hew_letters))
+    if not (
+        hew_letters.lower() == "null" or letterset.issubset(valid_letters)
+    ):
+        raise ValueError(
+            "Input failed validation. Must either be "
+            "a string consisting only of the letters "
+            f"in {valid_letters} or the string 'null'"
+        )
+    result = dict(
+        fit_hospital_admissions="h" in hew_letters,
+        fit_ed_visits="e" in hew_letters,
+        fit_wastewater="w" in hew_letters,
+    )
+    if not result:
+        result = "null"
+    return result
+
+
 def pyrenew_model_name_from_flags(
     fit_ed_visits: bool = False,
     fit_hospital_admissions: bool = False,

--- a/pyrenew_hew/util.py
+++ b/pyrenew_hew/util.py
@@ -78,8 +78,9 @@ def hew_letters_from_flags(
 
 def flags_from_hew_letters(hew_letters: str) -> dict[str, bool]:
     """
-    Get True/False flags defining whether signals
-    were fit from the {h, e, w} letters (or 'null')
+    Get a set of boolean flags indicating which
+    datastreams, if any, were used in fitting
+    from the {h, e, w} letters (or 'null')
     defining the model. Inverse of
     :func:`hew_letters_from_flags`
 
@@ -94,6 +95,13 @@ def flags_from_hew_letters(hew_letters: str) -> dict[str, bool]:
        Dictionary with boolean entries named
        ``fit_hospital_admissions``, ``fit_ed_visits``,
        and ``fit_wastewater``.
+
+    Raises
+    ------
+    ValueError
+        if input does is neither ``'null'`` nor a
+        combination of the letters
+        ``'h'``, ``'e'``, and ``'w'``.
     """
     valid_letters = {"h", "e", "w"}
     letterset = set(list(hew_letters))
@@ -124,7 +132,7 @@ def pyrenew_model_name_from_flags(
     Get a "pyrenew_{h,e,w}" model name
     string from a set of flags indicating which
     of the datastreams, if any, were used in fitting.
-    If none of them were, call the model "pyrenew_null"
+    If none of them were, call the model "pyrenew_null".
 
     Parameters
     ----------
@@ -148,3 +156,36 @@ def pyrenew_model_name_from_flags(
         fit_wastewater=fit_wastewater,
     )
     return f"pyrenew_{hew_letters}"
+
+
+def flags_from_pyrenew_model_name(model_name: str) -> dict[str, bool]:
+    """
+    Get a set of boolean flags indicating which
+    datastreams, if any, were used in fitting
+    from a "pyrenew_{h,e,w}" model name.
+
+    Parameters
+    ----------
+    model_name
+        The model name.
+
+    Returns
+    -------
+    dict[str, bool]
+       Dictionary with boolean entries named
+       ``fit_hospital_admissions``, ``fit_ed_visits``,
+       and ``fit_wastewater``.
+
+    Raises
+    ------
+    ValueError
+        If the input is not a valid pyrenew_{h, e, w} model name.
+
+    """
+    if not model_name.startswith("pyrenew_"):
+        raise ValueError(
+            "Expected a model_name beginning with "
+            f"'pyrenew_'. Got {model_name}."
+        )
+    hew_letters = model_name.removeprefix("pyrenew_")
+    return flags_from_hew_letters(hew_letters)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,7 @@ import pytest
 
 from pyrenew_hew.util import (
     flags_from_hew_letters,
+    flags_from_pyrenew_model_name,
     hew_letters_from_flags,
     hew_models,
     powerset,
@@ -32,6 +33,7 @@ from pyrenew_hew.util import (
 def test_hew_naming_from_flags(
     fit_ed_visits, fit_hospital_admissions, fit_wastewater, expected_letters
 ):
+    expected_model_name = f"pyrenew_{expected_letters}"
     assert (
         hew_letters_from_flags(
             fit_ed_visits, fit_hospital_admissions, fit_wastewater
@@ -43,10 +45,16 @@ def test_hew_naming_from_flags(
         pyrenew_model_name_from_flags(
             fit_ed_visits, fit_hospital_admissions, fit_wastewater
         )
-        == f"pyrenew_{expected_letters}"
+        == expected_model_name
     )
 
     assert flags_from_hew_letters(expected_letters) == dict(
+        fit_ed_visits=fit_ed_visits,
+        fit_hospital_admissions=fit_hospital_admissions,
+        fit_wastewater=fit_wastewater,
+    )
+
+    assert flags_from_pyrenew_model_name(expected_model_name) == dict(
         fit_ed_visits=fit_ed_visits,
         fit_hospital_admissions=fit_hospital_admissions,
         fit_wastewater=fit_wastewater,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,6 +3,7 @@ from typing import Iterable
 import pytest
 
 from pyrenew_hew.util import (
+    flags_from_hew_letters,
     hew_letters_from_flags,
     hew_models,
     powerset,
@@ -43,6 +44,12 @@ def test_hew_naming_from_flags(
             fit_ed_visits, fit_hospital_admissions, fit_wastewater
         )
         == f"pyrenew_{expected_letters}"
+    )
+
+    assert flags_from_hew_letters(expected_letters) == dict(
+        fit_ed_visits=fit_ed_visits,
+        fit_hospital_admissions=fit_hospital_admissions,
+        fit_wastewater=fit_wastewater,
     )
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -61,6 +61,15 @@ def test_hew_naming_from_flags(
     )
 
 
+def test_flag_from_string_errors():
+    with pytest.raises(ValueError, match="Must either be a string"):
+        flags_from_hew_letters("hewr")
+    with pytest.raises(ValueError, match="Must either be a string"):
+        flags_from_hew_letters("nulle")
+    with pytest.raises(ValueError, match="pyrenew_"):
+        flags_from_pyrenew_model_name("a_pyrenew_hew")
+
+
 @pytest.mark.parametrize(
     "test_items",
     [


### PR DESCRIPTION
## Goal
The `fit_{hospital_admissions|ed_visits|wastewater}` flags for `build_model_from_dir` should reflect the posterior that will be passed in, not necessarily what posterior predictions will be made (as determined by the `predict_<signal>` flags. Previously, we used the `predict_<signal>` flags.

## Changes
- Changes the names of the flags in `build_model_from_dir` from `sample_<signal>` to `fit_<signal>`, since they are only affect the fitting form of the model, not its use in prediction.
- Add (in `util.py`) helper functions that generate flag set dictionaries from sets of `hew` letters or full pyrenew model names
- Add tests for those functions.
- Use those functions to get the relevant `fit_{x}` flags for `build_model_from_dir` in `generate_and_save_predictions()`.