### PR TITLE
Update gitignore to reflect local blob mount workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,10 @@ private_data/*
 
 # Ignore end to end test output
 pipelines/tests/end_to_end_test_output/*
+
+# subdirs reserved for mounting blob storage containers
+config
+nssp-archival-vintages
+nssp-etl
+output
+params


### PR DESCRIPTION
Default paths where blob storage containers are mounted in `setup_pool.py`/`setup_prod_job.py` are now `.gitignore`d, allowing for a local setup that mirrors that in batch without risk of accidental commits.