### PR TITLE
Omit diagnostic report rendering

### DIFF
--- a/pipelines/forecast_state.py
+++ b/pipelines/forecast_state.py
@@ -478,10 +478,10 @@ def main(
     )
     logger.info("Postprocessing complete.")
 
-    if pyrenew_model_name == "pyrenew_e":
-        logger.info("Rendering webpage...")
-        render_diagnostic_report(model_run_dir)
-        logger.info("Rendering complete.")
+    # if pyrenew_model_name == "pyrenew_e":
+    #     logger.info("Rendering webpage...")
+    #     render_diagnostic_report(model_run_dir)
+    #     logger.info("Rendering complete.")
 
     if score:
         logger.info("Scoring forecast...")


### PR DESCRIPTION
The report only works for PyRenew-E at the moment and is rarely used. As we are undergoing some significant changes in https://github.com/CDCgov/pyrenew-hew/pull/388, I think we should disable the report, rather than put in the work to keep the unused, limited functionality report up to date.