### PR TITLE
allowing delete tag workflow to be run on main, protecting 'latest'

### DIFF
--- a/.github/workflows/delete-container-tag.yaml
+++ b/.github/workflows/delete-container-tag.yaml
@@ -17,7 +17,6 @@ jobs:
       contents: read
       packages: write
     environment: production
-    if: github.event.ref_type == 'branch'
     runs-on: ubuntu-latest
     name: Delete tag
 
@@ -28,7 +27,7 @@ jobs:
       - name: Figure out tag (either latest if it is main or the branch name)
         id: image-tag
         run: |
-          if [ "${{ github.event.ref }}" = "main" ]; then
+          if [ "${{ inputs.tag }}" = "latest" ]; then
             echo "The image associated with the main branch cannot be deleted."
             exit 1
           else


### PR DESCRIPTION
Prior workflow rules prevented the delete tag workflow from being run manually from the main branch ([ref](https://github.com/CDCgov/pyrenew-hew/actions/runs/14714867799)). Updated the workflow to allow the delete tag workflow to be manually run from the main branch while still protecting the 'latest' tag.