### PR TITLE
Tweak setup_pool.py

### DIFF
--- a/pipelines/batch/setup_pool.py
+++ b/pipelines/batch/setup_pool.py
@@ -5,7 +5,7 @@ import argparse
 import azuretools.defaults as d
 from azure.mgmt.batch import models
 from azuretools import blob
-from azuretools.auth import EnvCredentialHandler, get_compute_node_id_reference
+from azuretools.auth import EnvCredentialHandler
 from azuretools.client import get_batch_management_client
 
 
@@ -26,7 +26,7 @@ def main(pool_name: str) -> None:
 
     creds = EnvCredentialHandler()
     client = get_batch_management_client(creds)
-    node_id_ref = get_compute_node_id_reference()
+    node_id_ref = creds.compute_node_identity_reference
     pool_config = d.get_default_pool_config(
         pool_name=pool_name,
         subnet_id=creds.azure_subnet_id,


### PR DESCRIPTION
Simpler and clearer to get the compute node identity reference directly from the `CredentialHandler`. I am planning a breaking change to `cfa-azuretools` that will refactor and the rename the `get_compute_node_id_reference()` function to `get_compute_node_identity_reference()`; this change will prevent that one from breaking the pipeline.