### PR TITLE
UV Lock File Pre-Commit Hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,10 @@ repos:
         # Run the formatter
       - id: ruff-format
         args: ["--line-length", "79"]
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.7.5
+    hooks:
+      - id: uv-lock
   #####
   # R
   - repo: https://github.com/lorenzwalthert/precommit


### PR DESCRIPTION
This PR covers adding this suggested line to `pre-commit` configuration file for updating the `uv-lock` file automatically once the `pyproject.toml` file is updated (see [here](https://docs.astral.sh/uv/guides/integration/pre-commit/) for more details).

```yaml
- repo: https://github.com/astral-sh/uv-pre-commit
  rev: 0.7.3
  hooks:
  - id: uv-lock
```