### PR TITLE
avoid duplicate values for timeseries models

### DIFF
--- a/hewr/R/to_hub_quantile_table.R
+++ b/hewr/R/to_hub_quantile_table.R
@@ -48,7 +48,7 @@ model_fit_dir_to_hub_q_tbl <- function(model_fit_dir) {
   samples_paths <- fs::dir_ls(
     model_fit_dir,
     recurse = TRUE,
-    glob = "*samples*.parquet"
+    glob = "*samples.parquet"
   )
   quantiles_paths <- fs::dir_ls(
     model_fit_dir,


### PR DESCRIPTION
```
  library(arrow)
 library(tidyverse)
 read_parquet("pyrenew-hew/pipelines/tests/end_to_end_test_output/2024-12-21_forecasts/influenza_r_2024-12-21_f_2024-09-22_t_2024-12-20/2024-12-21-influenza-hubverse-table.parquet") |>
   group_by(model_id) |> 
   nest() |> 
   mutate(
     n = map_int(data, nrow),
     n_distinct = map_int(data, \(x) nrow(distinct(x)))
   )  |> 
   select(-data) |> 
   filter(n != n_distinct)
# A tibble: 0 × 3
# Groups:   model_id [0]
# ℹ 3 variables: model_id <glue>, n <int>, n_distinct <int>