### PR TITLE
Removing container build cacheing to assess build reliability without it

### DIFF
--- a/.github/scripts/docker_build_and_push.sh
+++ b/.github/scripts/docker_build_and_push.sh
@@ -8,11 +8,19 @@ BUILDER=docker-container-driver-builder
 docker buildx create --name "$BUILDER" --driver=docker-container || true
 
 # use the registry cache for prior images of the same tag, or the 'latest' tag
+# time docker buildx build --push -t "$IMAGE:$TAG" \
+# 	--builder "$BUILDER" \
+# 	--build-arg "GIT_COMMIT_SHA=$GIT_COMMIT_SHA" \
+# 	--build-arg "GIT_BRANCH_NAME=$GIT_BRANCH_NAME" \
+# 	--cache-from "type=registry,ref=$IMAGE:$TAG-cache" \
+# 	--cache-from "type=registry,ref=$IMAGE:latest-cache" \
+# 	--cache-to "type=registry,ref=$IMAGE:$TAG-cache,mode=max" \
+# 	-f Containerfile .
+
+# attempt without registry cache - we care less about speed 
+# and more about deterministic rebuilds
 time docker buildx build --push -t "$IMAGE:$TAG" \
 	--builder "$BUILDER" \
 	--build-arg "GIT_COMMIT_SHA=$GIT_COMMIT_SHA" \
 	--build-arg "GIT_BRANCH_NAME=$GIT_BRANCH_NAME" \
-	--cache-from "type=registry,ref=$IMAGE:$TAG-cache" \
-	--cache-from "type=registry,ref=$IMAGE:latest-cache" \
-	--cache-to "type=registry,ref=$IMAGE:$TAG-cache,mode=max" \
 	-f Containerfile .


### PR DESCRIPTION
Running tests. Will request review. It probably makes sense to leave the cache code commented in the script as we may change our mind again :) 