### PR TITLE
reindex chains

### DIFF
--- a/hewr/R/process_loc_forecast.R
+++ b/hewr/R/process_loc_forecast.R
@@ -326,7 +326,7 @@ process_pyrenew_model <- function(
       aggregated_numerator = FALSE,
       aggregated_denominator = NA,
     ) |>
-    dplyr::mutate(dplyr::across(c(".chain", ".iteration"), \(x) x + 1)) |> 
+    dplyr::mutate(dplyr::across(c(".chain", ".iteration"), \(x) x + 1)) |>
     tidybayes::combine_chains() |>
     dplyr::select(tidyselect::all_of(required_columns))
 

--- a/hewr/R/process_loc_forecast.R
+++ b/hewr/R/process_loc_forecast.R
@@ -326,6 +326,7 @@ process_pyrenew_model <- function(
       aggregated_numerator = FALSE,
       aggregated_denominator = NA,
     ) |>
+    dplyr::mutate(dplyr::across(c(".chain", ".iteration"), \(x) x + 1)) |> 
     tidybayes::combine_chains() |>
     dplyr::select(tidyselect::all_of(required_columns))
 


### PR DESCRIPTION
0 indexing from arviz leads to invalid draws column
``` r
tibble::tibble(.chain = 0, .iteration = seq(0, 9, by = 1)) |> 
  tidybayes::combine_chains()
#> # A tibble: 10 × 3
#>    .chain .iteration .draw
#>     <dbl>      <dbl> <int>
#>  1      0          0    -9
#>  2      0          1    -8
#>  3      0          2    -7
#>  4      0          3    -6
#>  5      0          4    -5
#>  6      0          5    -4
#>  7      0          6    -3
#>  8      0          7    -2
#>  9      0          8    -1
#> 10      0          9     0
```

<sup>Created on 2025-09-18 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>