### PR TITLE
Fix Disease Variable In Pipelines Utilities Script

### DIFF
--- a/pipelines/postprocess_forecast_batches.py
+++ b/pipelines/postprocess_forecast_batches.py
@@ -62,7 +62,7 @@ def main(
 ) -> None:
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
-    to_process = get_all_forecast_dirs(base_forecast_dir, diseases)
+    to_process = get_all_forecast_dirs(base_forecast_dir, list(diseases))
     for batch_dir in to_process:
         logger.info(f"Processing {batch_dir}...")
         model_batch_dir_path = Path(base_forecast_dir, batch_dir)

--- a/pipelines/utils.py
+++ b/pipelines/utils.py
@@ -59,7 +59,7 @@ def parse_model_batch_dir_name(model_batch_dir_name: str) -> dict:
 
 def get_all_forecast_dirs(
     parent_dir: Path | str,
-    diseases: str | set[str],
+    diseases: str | list[str],
     report_date: str | dt.date = None,
 ) -> list[str]:
     """
@@ -73,7 +73,7 @@ def get_all_forecast_dirs(
        Directory in which to look for forecast subdirectories.
 
     diseases
-       Name of the diseases to match, as a set of strings,
+       Name of the diseases to match, as a list of strings,
        or a single disease as a string.
 
     Returns
@@ -87,7 +87,7 @@ def get_all_forecast_dirs(
     ValueError
         Given an invalid ``report_date``.
     """
-    diseases = ensure_listlike(list(diseases))
+    diseases = ensure_listlike(diseases)
 
     if report_date is None:
         report_date_str = ""


### PR DESCRIPTION
This PR:

* [x] Fixes the `disease` argument to `get_all_forecast_dirs` in `pipelines/utils.py` by casting `disease` as a `list`.

The original error:

<img width="927" height="330" alt="Screenshot 2025-09-24 at 15 10 24" src="https://github.com/user-attachments/assets/b5961bad-4561-4dca-a101-83f92802e042" />
