### PR TITLE
Issue 759: Add `julia` to `Containerfile` along with `EpiAutoGP` deps

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -11,6 +11,7 @@ ENV GIT_BRANCH_NAME=$GIT_BRANCH_NAME
 ENV XLA_FLAGS=--xla_force_host_platform_device_count=4
 
 COPY ./hewr /pyrenew-hew/hewr
+COPY ./EpiAutoGP /pyrenew-hew/EpiAutoGP
 
 WORKDIR /pyrenew-hew
 
@@ -24,6 +25,10 @@ COPY pipelines/priors pipelines/priors
 
 # Python from https://docs.astral.sh/uv/guides/integration/docker/
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Julia 1.11 from official image
+COPY --from=julia:1.11 /usr/local/julia /usr/local/julia
+ENV PATH="/usr/local/julia/bin:${PATH}"
+
 # Some handy uv environment variables
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
@@ -31,3 +36,7 @@ ENV UV_PYTHON_CACHE_DIR=/root/.cache/uv/python
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync
+
+# Cache Julia packages and artifacts
+RUN --mount=type=cache,target=/root/.julia \
+    julia --project=EpiAutoGP -e 'using Pkg; Pkg.instantiate()'


### PR DESCRIPTION
This PR modifies the `Containerfile` to get `julia 1.11` from its official docker image, and then install/pre-compile the deps for `EpiAutoGP`.

This PR closes #759 