### PR TITLE
Check for `typing.Optional` annotations that can be rewritten

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
 fix = true
 
 [tool.ruff.lint]
-select = ["I", "E4", "E7", "E9", "F"]
+select = ["I", "E4", "E7", "E9", "F", "UP045"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "pipelines/tests"]


### PR DESCRIPTION
Closes https://github.com/CDCgov/pyrenew-hew/issues/774