### PR TITLE
rm launcher config, rm image config in prod

### DIFF
--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -106,7 +106,6 @@ image = f"ghcr.io/cdcgov/cfa-stf-routine-forecasting:{tag}"
 # In prod, launches on the code location but runs in Azure Container App Jobs
 # Used for lightweight assets and jobs, etc. where volume mounts are not needed
 basic_execution_config = ExecutionConfig(
-    launcher=SelectorConfig(class_name=dg.DefaultRunLauncher.__name__),
     executor=SelectorConfig(
         class_name=azure_container_app_job_executor.__name__
         if is_production
@@ -117,7 +116,6 @@ basic_execution_config = ExecutionConfig(
 # Launches locally, executes in a docker container as configured below
 # Allows for rapid local testing in a similar-to-batch environment
 docker_execution_config = ExecutionConfig(
-    launcher=SelectorConfig(class_name=dg.DefaultRunLauncher.__name__),
     executor=SelectorConfig(
         class_name=docker_executor.__name__,
         config={
@@ -150,12 +148,15 @@ docker_execution_config = ExecutionConfig(
 
 # Cloud execution. This is what we want for any model run.
 azure_batch_execution_config = ExecutionConfig(
-    launcher=SelectorConfig(class_name=dg.DefaultRunLauncher.__name__),
     executor=SelectorConfig(
         class_name=azure_batch_executor.__name__,
         config={
             "pool_name": "pyrenew-dagster-pool",
-            "image": image,
+            **(
+                {}
+                if is_production  # image will come from the code location in prod
+                else {"image": image}
+            ),
             "env_vars": [
                 "VIRTUAL_ENV=/cfa-stf-routine-forecasting/.venv",
             ],


### PR DESCRIPTION
The launcher config here had all runs launching from the code location. With only 0.5 CPU, this left the code location locked up and failing health checks causing internal restarts. By removing the launcher config, we leave it to the cfa-dagster defaults. In production, this will launch runs in their own Container App Job, leaving the code location free. Note: this does NOT prevent the steps within the run from using Azure Batch.

The second change here is to remove the `image` config from the Batch executor in production. This will allow the Batch executor to use the code location image. Most of the time in production, this will be the `latest` tag, but this change allows us to deploy arbitrary images to the code location and test against that image:
<img width="887" height="596" alt="image" src="https://github.com/user-attachments/assets/3dbd64c9-17b9-4d46-a47e-c630b80c117a" />
Further confirmation this image was used to successfully [run](https://dagster.apps.edav.ext.cdc.gov/runs/0887f0bb-77ff-4a0b-b7ff-2e74808ad0c4?logFileKey=rwpswatl&selection=%2A) all the model assets (besides pyrenew h and he):
<img width="1982" height="1100" alt="image" src="https://github.com/user-attachments/assets/2da4f192-0994-493e-9afd-d7c5a402ace7" />
