### PR TITLE
Add eager condition to fusion models; remove all nwss/w entities

### DIFF
--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -512,12 +512,9 @@ def _fuse_pyrenew_timeseries(context, config, pyrenew_model_name, epiweekly: boo
         fusion_model_name=fusion_model_name,
     )
 
+# ---------- Initial Forecast Assets ----------
 
-# ---------- Automation Conditions ----------
-# A condition that will run as soon as all dependencies are available, but only
-# if the asset has not been materialized yet for that day
-eager_once = dg.AutomationCondition.eager() & dg.AutomationCondition.missing()
-
+# Asset decorator arguments for all initial forecast models
 weekly_forecast_initial_args = {
     "partitions_def": daily_partitions_def,
     "graph_dimensions": ["diseases", "locations"],
@@ -526,10 +523,6 @@ weekly_forecast_initial_args = {
     ),
     "group_name": "WeeklyForecast",
 }
-
-
-# ---------- Initial Forecast Assets ----------
-
 
 # Timeseries E
 @dynamic_graph_asset(
@@ -592,11 +585,12 @@ def pyrenew_he(
 
 # ---------- Fusion Forecasts ----------
 
+# Asset decorator arguments for all fusion forecast models
 weekly_forecast_fusion_args = {
     "partitions_def": daily_partitions_def,
     "graph_dimensions": ["diseases", "locations"],
-    "group_name": "WeeklyForecast",
-    "automation_condition": dg.AutomationCondition.eager()
+    "automation_condition": dg.AutomationCondition.eager(),
+    "group_name": "WeeklyForecast"
 }
 
 

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -512,6 +512,7 @@ def _fuse_pyrenew_timeseries(context, config, pyrenew_model_name, epiweekly: boo
         fusion_model_name=fusion_model_name,
     )
 
+
 # ---------- Initial Forecast Assets ----------
 
 # Asset decorator arguments for all initial forecast models
@@ -523,6 +524,7 @@ weekly_forecast_initial_args = {
     ),
     "group_name": "WeeklyForecast",
 }
+
 
 # Timeseries E
 @dynamic_graph_asset(
@@ -591,7 +593,7 @@ weekly_forecast_fusion_args = {
     "partitions_def": daily_partitions_def,
     "graph_dimensions": ["diseases", "locations"],
     "automation_condition": dg.AutomationCondition.eager(),
-    "group_name": "WeeklyForecast"
+    "group_name": "WeeklyForecast",
 }
 
 

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -643,50 +643,13 @@ def pyrenew_he(
 ):
     _run_pyrenew_model(context, config, "he")
 
-
-# Pyrenew HW
-@dynamic_graph_asset(
-    partitions_def=daily_partitions_def,
-    graph_dimensions=["diseases", "locations"],
-    # automation_condition=eager_once,
-    group_name="WeeklyForecastArchived",
-    ins={
-        "nwss_gold_stf": dg.In(dg.Nothing),
-        "nhsn_data_stf": dg.In(dg.Nothing),
-    },
-)
-def pyrenew_hw(
-    context: DynamicGraphAssetExecutionContext,
-    config: PyrenewWConfig,
-):
-    _run_pyrenew_model(context, config, "hw")
-
-
-# Pyrenew HEW
-@dynamic_graph_asset(
-    partitions_def=daily_partitions_def,
-    graph_dimensions=["diseases", "locations"],
-    # automation_condition=eager_once,
-    group_name="WeeklyForecastArchived",
-    ins={
-        "nssp_gold_v1": dg.In(dg.Nothing),
-        "nwss_gold_stf": dg.In(dg.Nothing),
-        "nhsn_data_stf": dg.In(dg.Nothing),
-    },
-)
-def pyrenew_hew(
-    context: DynamicGraphAssetExecutionContext,
-    config: PyrenewEWConfig,
-):
-    _run_pyrenew_model(context, config, "hew")
-
-
 # ---------- Fusion Forecasts ----------
 
 weekly_forecast_fusion_args = {
     "partitions_def": daily_partitions_def,
     "graph_dimensions": ["diseases", "locations"],
     "group_name": "WeeklyForecast",
+    "automation_condition": dg.AutomationCondition.eager()
 }
 
 
@@ -735,34 +698,6 @@ def fuse_pyrenew_he_ts_epiweekly(
 ):
     _fuse_pyrenew_timeseries(
         context, config, pyrenew_model_name="pyrenew_he", epiweekly=True
-    )
-
-
-@dynamic_graph_asset(
-    partitions_def=daily_partitions_def,
-    graph_dimensions=["diseases", "locations"],
-    group_name="WeeklyForecastArchived",
-    ins={"pyrenew_hew": dg.In(dg.Nothing), "timeseries_e": dg.In(dg.Nothing)},
-)
-def fuse_pyrenew_hew_ts(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
-):
-    _fuse_pyrenew_timeseries(
-        context, config, pyrenew_model_name="pyrenew_hew", epiweekly=False
-    )
-
-
-@dynamic_graph_asset(
-    partitions_def=daily_partitions_def,
-    graph_dimensions=["diseases", "locations"],
-    group_name="WeeklyForecastArchived",
-    ins={"pyrenew_hew": dg.In(dg.Nothing), "epiweekly_timeseries_e": dg.In(dg.Nothing)},
-)
-def fuse_pyrenew_hew_ts_epiweekly(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
-):
-    _fuse_pyrenew_timeseries(
-        context, config, pyrenew_model_name="pyrenew_hew", epiweekly=True
     )
 
 

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -7,8 +7,6 @@ from zoneinfo import ZoneInfo
 # Direct use of dagster
 import dagster as dg
 import requests
-from azure.identity import DefaultAzureCredential
-from azure.storage.blob import BlobServiceClient
 from cfa_dagster import (
     ADLS2PickleIOManager,
     DynamicGraphAssetExecutionContext,
@@ -277,6 +275,7 @@ class PostProcessConfig(dg.Config):
 # TODO: either add these to pipelines/utils or deprecate altogether by virtue
 # of having these upstream data materialized in dagster directly
 
+
 def _check_nhsn_data_availability(context: dg.AssetExecutionContext):
     current_date = context.partition_key
     nhsn_target_url = "https://data.cdc.gov/api/views/mpgq-jmmr.json"
@@ -305,6 +304,7 @@ def _check_nhsn_data_availability(context: dg.AssetExecutionContext):
 
 
 # ----------- Upstream Data Availability Assets ----
+
 
 # NHSN
 @dg.asset(
@@ -590,13 +590,14 @@ def pyrenew_he(
 ):
     _run_pyrenew_model(context, config, "he")
 
+
 # ---------- Fusion Forecasts ----------
 
 weekly_forecast_fusion_args = {
     "partitions_def": daily_partitions_def,
     "graph_dimensions": ["diseases", "locations"],
     "group_name": "WeeklyForecast",
-    "automation_condition": dg.AutomationCondition.eager()
+    "automation_condition": dg.AutomationCondition.eager(),
 }
 
 

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -235,6 +235,11 @@ class PyrenewConfig(ModelBaseConfig):
     additional_forecast_letters: str = ""
 
 
+class FusionConfig(ModelBaseConfig):
+    # filter out WY
+    locations: list[str] = [loc for loc in LOCATIONS if loc != "WY"]
+
+
 class PyrenewEConfig(PyrenewConfig):
     # filter out WY
     locations: list[str] = [loc for loc in LOCATIONS if loc != "WY"]
@@ -427,7 +432,7 @@ def _run_pyrenew_model(
 
 
 def get_model_loc_dir(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
+    context: DynamicGraphAssetExecutionContext, config: FusionConfig
 ) -> Path:
     disease = context.graph_dimension["diseases"]
     location = context.graph_dimension["locations"]
@@ -459,7 +464,7 @@ def get_model_loc_dir(
 
 def _run_fusion_model(
     context: DynamicGraphAssetExecutionContext,
-    config: ModelBaseConfig,
+    config: FusionConfig,
     num_model_name,
     other_model_name,
     aggregate_num,
@@ -494,7 +499,9 @@ def _run_fusion_model(
     context.log.debug(f"config: '{config}'")
 
 
-def _fuse_pyrenew_timeseries(context, config, pyrenew_model_name, epiweekly: bool):
+def _fuse_pyrenew_timeseries(
+    context, config: FusionConfig, pyrenew_model_name, epiweekly: bool
+):
     other_model_name = "epiweekly_ts_ensemble_e" if epiweekly else "daily_ts_ensemble_e"
     fusion_model_name = (
         f"prop_epiweekly_aggregated_{pyrenew_model_name}_epiweekly_ts_ensemble_e"
@@ -601,9 +608,7 @@ weekly_forecast_fusion_args = {
     **weekly_forecast_fusion_args,
     ins={"pyrenew_e": dg.In(dg.Nothing), "timeseries_e": dg.In(dg.Nothing)},
 )
-def fuse_pyrenew_e_ts(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
-):
+def fuse_pyrenew_e_ts(context: DynamicGraphAssetExecutionContext, config: FusionConfig):
     _fuse_pyrenew_timeseries(
         context, config, pyrenew_model_name="pyrenew_e", epiweekly=False
     )
@@ -614,7 +619,7 @@ def fuse_pyrenew_e_ts(
     ins={"pyrenew_e": dg.In(dg.Nothing), "epiweekly_timeseries_e": dg.In(dg.Nothing)},
 )
 def fuse_pyrenew_e_ts_epiweekly(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
+    context: DynamicGraphAssetExecutionContext, config: FusionConfig
 ):
     _fuse_pyrenew_timeseries(
         context, config, pyrenew_model_name="pyrenew_e", epiweekly=True
@@ -626,7 +631,7 @@ def fuse_pyrenew_e_ts_epiweekly(
     ins={"pyrenew_he": dg.In(dg.Nothing), "timeseries_e": dg.In(dg.Nothing)},
 )
 def fuse_pyrenew_he_ts(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
+    context: DynamicGraphAssetExecutionContext, config: FusionConfig
 ):
     _fuse_pyrenew_timeseries(
         context, config, pyrenew_model_name="pyrenew_he", epiweekly=False
@@ -638,7 +643,7 @@ def fuse_pyrenew_he_ts(
     ins={"pyrenew_he": dg.In(dg.Nothing), "epiweekly_timeseries_e": dg.In(dg.Nothing)},
 )
 def fuse_pyrenew_he_ts_epiweekly(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
+    context: DynamicGraphAssetExecutionContext, config: FusionConfig
 ):
     _fuse_pyrenew_timeseries(
         context, config, pyrenew_model_name="pyrenew_he", epiweekly=True

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -277,7 +277,6 @@ class PostProcessConfig(dg.Config):
 # TODO: either add these to pipelines/utils or deprecate altogether by virtue
 # of having these upstream data materialized in dagster directly
 
-
 def _check_nhsn_data_availability(context: dg.AssetExecutionContext):
     current_date = context.partition_key
     nhsn_target_url = "https://data.cdc.gov/api/views/mpgq-jmmr.json"
@@ -305,35 +304,7 @@ def _check_nhsn_data_availability(context: dg.AssetExecutionContext):
         return {"exists": False, "reason": str(e)}
 
 
-def _check_nwss_gold_data_availability(
-    context: dg.AssetExecutionContext,
-    account_name="cfaazurebatchprd",
-    container_name="nwss-vintages",
-):
-    current_date = context.partition_key
-    folder_prefix = "NWSS-ETL-covid-"
-    target_folder = f"{folder_prefix}{current_date}/"
-    credential = DefaultAzureCredential()
-    blob_service_client = BlobServiceClient(
-        f"https://{account_name}.blob.core.windows.net", credential=credential
-    )
-    container_client = blob_service_client.get_container_client(container_name)
-    all_blobs = list(container_client.list_blobs(name_starts_with=folder_prefix))
-    latest_blob = max(all_blobs, key=lambda b: b.last_modified).name
-    target_blob = list(container_client.list_blobs(name_starts_with=target_folder))
-    nwss_gold_check = latest_blob == target_blob
-    result = {
-        "exists": nwss_gold_check,
-        "latest_blob": latest_blob,
-        "target_folder": target_folder,
-        "target_blob": target_blob,
-        "current_date": current_date,
-    }
-    return result
-
-
 # ----------- Upstream Data Availability Assets ----
-
 
 # NHSN
 @dg.asset(
@@ -357,30 +328,6 @@ def nhsn_data_stf(context: dg.AssetExecutionContext):
         yield dg.Output("nhsn_data_stf")
     else:
         context.log.error(f"NHSN data not available: {result}")
-
-
-# NWSS
-@dg.asset(
-    partitions_def=daily_partitions_def,
-    automation_condition=(
-        # Check every hour 6am-4pm on Wednesday for new data;
-        dg.AutomationCondition.cron_tick_passed(
-            cron_schedule="0 6-16 * * WED", cron_timezone="America/New_York"
-        )
-        # don't check if not-missing for that day
-        & dg.AutomationCondition.in_latest_time_window()
-        & dg.AutomationCondition.missing()
-    ),
-    group_name="UpstreamData",
-    output_required=False,
-)
-def nwss_gold_stf(context: dg.AssetExecutionContext):
-    result = _check_nwss_gold_data_availability(context)
-    if result["exists"]:
-        context.log.info(f"NWSS gold data available: {result}")
-        yield dg.Output("nwss_gold_stf")
-    else:
-        context.log.error(f"NWSS gold data not available: {result}")
 
 
 # ----------- Model Constructor Functions --------------------------


### PR DESCRIPTION
- Fusion models should launch as soon as their upstream dependencies are available, and then re-launch when any updates appear upstream.
- We are not using `w` models currently. Let's remove them and add them back if eventually needed.