### PR TITLE
exclude wyoming from fusion models

### DIFF
--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -234,6 +234,7 @@ class PyrenewConfig(ModelBaseConfig):
     rng_key: int = 12345
     additional_forecast_letters: str = ""
 
+
 class FusionConfig(ModelBaseConfig):
     # filter out WY
     locations: list[str] = [loc for loc in LOCATIONS if loc != "WY"]
@@ -498,7 +499,9 @@ def _run_fusion_model(
     context.log.debug(f"config: '{config}'")
 
 
-def _fuse_pyrenew_timeseries(context, config: FusionConfig, pyrenew_model_name, epiweekly: bool):
+def _fuse_pyrenew_timeseries(
+    context, config: FusionConfig, pyrenew_model_name, epiweekly: bool
+):
     other_model_name = "epiweekly_ts_ensemble_e" if epiweekly else "daily_ts_ensemble_e"
     fusion_model_name = (
         f"prop_epiweekly_aggregated_{pyrenew_model_name}_epiweekly_ts_ensemble_e"
@@ -605,9 +608,7 @@ weekly_forecast_fusion_args = {
     **weekly_forecast_fusion_args,
     ins={"pyrenew_e": dg.In(dg.Nothing), "timeseries_e": dg.In(dg.Nothing)},
 )
-def fuse_pyrenew_e_ts(
-    context: DynamicGraphAssetExecutionContext, config: FusionConfig
-):
+def fuse_pyrenew_e_ts(context: DynamicGraphAssetExecutionContext, config: FusionConfig):
     _fuse_pyrenew_timeseries(
         context, config, pyrenew_model_name="pyrenew_e", epiweekly=False
     )

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -234,6 +234,10 @@ class PyrenewConfig(ModelBaseConfig):
     rng_key: int = 12345
     additional_forecast_letters: str = ""
 
+class FusionConfig(ModelBaseConfig):
+    # filter out WY
+    locations: list[str] = [loc for loc in LOCATIONS if loc != "WY"]
+
 
 class PyrenewEConfig(PyrenewConfig):
     # filter out WY
@@ -427,7 +431,7 @@ def _run_pyrenew_model(
 
 
 def get_model_loc_dir(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
+    context: DynamicGraphAssetExecutionContext, config: FusionConfig
 ) -> Path:
     disease = context.graph_dimension["diseases"]
     location = context.graph_dimension["locations"]
@@ -459,7 +463,7 @@ def get_model_loc_dir(
 
 def _run_fusion_model(
     context: DynamicGraphAssetExecutionContext,
-    config: ModelBaseConfig,
+    config: FusionConfig,
     num_model_name,
     other_model_name,
     aggregate_num,
@@ -494,7 +498,7 @@ def _run_fusion_model(
     context.log.debug(f"config: '{config}'")
 
 
-def _fuse_pyrenew_timeseries(context, config, pyrenew_model_name, epiweekly: bool):
+def _fuse_pyrenew_timeseries(context, config: FusionConfig, pyrenew_model_name, epiweekly: bool):
     other_model_name = "epiweekly_ts_ensemble_e" if epiweekly else "daily_ts_ensemble_e"
     fusion_model_name = (
         f"prop_epiweekly_aggregated_{pyrenew_model_name}_epiweekly_ts_ensemble_e"
@@ -602,7 +606,7 @@ weekly_forecast_fusion_args = {
     ins={"pyrenew_e": dg.In(dg.Nothing), "timeseries_e": dg.In(dg.Nothing)},
 )
 def fuse_pyrenew_e_ts(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
+    context: DynamicGraphAssetExecutionContext, config: FusionConfig
 ):
     _fuse_pyrenew_timeseries(
         context, config, pyrenew_model_name="pyrenew_e", epiweekly=False
@@ -614,7 +618,7 @@ def fuse_pyrenew_e_ts(
     ins={"pyrenew_e": dg.In(dg.Nothing), "epiweekly_timeseries_e": dg.In(dg.Nothing)},
 )
 def fuse_pyrenew_e_ts_epiweekly(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
+    context: DynamicGraphAssetExecutionContext, config: FusionConfig
 ):
     _fuse_pyrenew_timeseries(
         context, config, pyrenew_model_name="pyrenew_e", epiweekly=True
@@ -626,7 +630,7 @@ def fuse_pyrenew_e_ts_epiweekly(
     ins={"pyrenew_he": dg.In(dg.Nothing), "timeseries_e": dg.In(dg.Nothing)},
 )
 def fuse_pyrenew_he_ts(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
+    context: DynamicGraphAssetExecutionContext, config: FusionConfig
 ):
     _fuse_pyrenew_timeseries(
         context, config, pyrenew_model_name="pyrenew_he", epiweekly=False
@@ -638,7 +642,7 @@ def fuse_pyrenew_he_ts(
     ins={"pyrenew_he": dg.In(dg.Nothing), "epiweekly_timeseries_e": dg.In(dg.Nothing)},
 )
 def fuse_pyrenew_he_ts_epiweekly(
-    context: DynamicGraphAssetExecutionContext, config: ModelBaseConfig
+    context: DynamicGraphAssetExecutionContext, config: FusionConfig
 ):
     _fuse_pyrenew_timeseries(
         context, config, pyrenew_model_name="pyrenew_he", epiweekly=True


### PR DESCRIPTION
New class `FusionConfig` which is identical to `ModelBaseConfig` except it filters out `WY` from the config, similar to `PyrenewEConfig`

Fixes #1040 