### PR TITLE
Partial hotfix to allow fusion+postprocessing automation to continue as intended

### DIFF
--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -462,7 +462,13 @@ def _fuse_pyrenew_timeseries(
 weekly_forecast_sensor = dg.AutomationConditionSensorDefinition(
     name="WeeklyForecast",
     target=dg.AssetSelection.groups("WeeklyForecast"),
-    use_user_code_server=True,  # allows for custom automation conditions
+    use_user_code_server=True # allows for custom automation conditions
+)
+
+weekly_forecast_fusion_sensor = dg.AutomationConditionSensorDefinition(
+    name="WeeklyForecastFusion",
+    target=dg.AssetSelection.groups("WeeklyForecastFusion"),
+    use_user_code_server=False # does NOT allow custom conditions
 )
 
 
@@ -515,7 +521,7 @@ class IsWeekday(dg.AutomationCondition):
 weekly_forecast_initial_asset_args = {
     "partitions_def": daily_partitions_def,
     "graph_dimensions": ["diseases", "locations"],
-    "group_name": "WeeklyForecast",
+    "group_name": "WeeklyForecastInitial",
     "automation_condition": (
         # We specifically don't want these to run unless it's Wednesday
         # 0=monday,1=tuesday,2=wednesday,etc.
@@ -526,6 +532,7 @@ weekly_forecast_initial_asset_args = {
 
 weekly_forecast_fusion_asset_args = {
     **weekly_forecast_initial_asset_args,
+    "group_name": "WeeklyForecastFusion",
     # we want vanilla eager for the fusion assets and post-processing
     "automation_condition": dg.AutomationCondition.eager(),
 }
@@ -685,7 +692,7 @@ def fuse_pyrenew_he_ts_epiweekly(
             ),
         )
     ).with_label("postprocess_custom_eager"),
-    group_name="WeeklyForecast",
+    group_name="WeeklyForecastFusion",
 )
 def postprocess_forecasts(
     context: dg.AssetExecutionContext,

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -460,8 +460,8 @@ def _fuse_pyrenew_timeseries(
 # ============================================================================
 
 weekly_forecast_sensor = dg.AutomationConditionSensorDefinition(
-    name="WeeklyForecast",
-    target=dg.AssetSelection.groups("WeeklyForecast"),
+    name="WeeklyForecastUpstream",
+    target=dg.AssetSelection.groups("WeeklyForecastUpstream"),
     use_user_code_server=True # allows for custom automation conditions
 )
 
@@ -518,10 +518,10 @@ class IsWeekday(dg.AutomationCondition):
 # partitions, graph_dimensions, automation conditions, and asset groups
 # The only thing that differs between them are their dependencies
 
-weekly_forecast_initial_asset_args = {
+weekly_forecast_upstream_asset_args = {
     "partitions_def": daily_partitions_def,
     "graph_dimensions": ["diseases", "locations"],
-    "group_name": "WeeklyForecastInitial",
+    "group_name": "WeeklyForecastUpstream",
     "automation_condition": (
         # We specifically don't want these to run unless it's Wednesday
         # 0=monday,1=tuesday,2=wednesday,etc.
@@ -531,7 +531,7 @@ weekly_forecast_initial_asset_args = {
 }
 
 weekly_forecast_fusion_asset_args = {
-    **weekly_forecast_initial_asset_args,
+    **weekly_forecast_upstream_asset_args,
     "group_name": "WeeklyForecastFusion",
     # we want vanilla eager for the fusion assets and post-processing
     "automation_condition": dg.AutomationCondition.eager(),
@@ -564,7 +564,7 @@ if not is_production:
 
 # Timeseries E
 @dynamic_graph_asset(
-    **weekly_forecast_initial_asset_args,
+    **weekly_forecast_upstream_asset_args,
     ins={"nssp_gold_v1": dg.In(dg.Nothing)},
 )
 def timeseries_e(context: DynamicGraphAssetExecutionContext, config: TimeseriesConfig):
@@ -573,7 +573,7 @@ def timeseries_e(context: DynamicGraphAssetExecutionContext, config: TimeseriesC
 
 # Epiweekly Timeseries E
 @dynamic_graph_asset(
-    **weekly_forecast_initial_asset_args,
+    **weekly_forecast_upstream_asset_args,
     ins={"nssp_gold_v1": dg.In(dg.Nothing)},
 )
 def epiweekly_timeseries_e(
@@ -584,7 +584,7 @@ def epiweekly_timeseries_e(
 
 # Pyrenew E
 @dynamic_graph_asset(
-    **weekly_forecast_initial_asset_args,
+    **weekly_forecast_upstream_asset_args,
     ins={
         "nssp_gold_v1": dg.In(dg.Nothing),
     },
@@ -598,7 +598,7 @@ def pyrenew_e(
 
 # Pyrenew H
 @dynamic_graph_asset(
-    **weekly_forecast_initial_asset_args,
+    **weekly_forecast_upstream_asset_args,
     ins={
         "nhsn_hrd_prelim": dg.In(dg.Nothing),
     },
@@ -609,7 +609,7 @@ def pyrenew_h(context: DynamicGraphAssetExecutionContext, config: PyrenewConfig)
 
 # Pyrenew HE
 @dynamic_graph_asset(
-    **weekly_forecast_initial_asset_args,
+    **weekly_forecast_upstream_asset_args,
     ins={
         "nhsn_hrd_prelim": dg.In(dg.Nothing),
     },

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -459,7 +459,7 @@ def _fuse_pyrenew_timeseries(
 # SCHEDULES AND AUTOMATION CONDITION SENSORS
 # ============================================================================
 
-weekly_forecast_sensor = dg.AutomationConditionSensorDefinition(
+weekly_forecast_upstream_sensor = dg.AutomationConditionSensorDefinition(
     name="WeeklyForecastUpstream",
     target=dg.AssetSelection.groups("WeeklyForecastUpstream"),
     use_user_code_server=True # allows for custom automation conditions

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -462,13 +462,13 @@ def _fuse_pyrenew_timeseries(
 weekly_forecast_sensor = dg.AutomationConditionSensorDefinition(
     name="WeeklyForecastUpstream",
     target=dg.AssetSelection.groups("WeeklyForecastUpstream"),
-    use_user_code_server=True # allows for custom automation conditions
+    use_user_code_server=True,  # allows for custom automation conditions
 )
 
 weekly_forecast_fusion_sensor = dg.AutomationConditionSensorDefinition(
     name="WeeklyForecastFusion",
     target=dg.AssetSelection.groups("WeeklyForecastFusion"),
-    use_user_code_server=False # does NOT allow custom conditions
+    use_user_code_server=False,  # does NOT allow custom conditions
 )
 
 


### PR DESCRIPTION
__A partial hotfix and workaround to give us breathing room:__
- We are getting user code server errors when evaluating our new `IsWeekday()` automation condition that we did not get when testing. 
- We can still run initial forecast assets manually; by giving the fusion and post-processing assets their own sensor, their non-custom eager evaluations should work again once manual runs of the initial forecast assets are complete. 