### PR TITLE
More flexible ensure_listlike

### DIFF
--- a/cfa/stf/forecasttools/__init__.py
+++ b/cfa/stf/forecasttools/__init__.py
@@ -3,7 +3,7 @@
 from importlib import import_module
 
 from .location_constants import LOCATION_LIST
-from .utils import coalesce_common_columns, ensure_listlike
+from .utils import coalesce_common_columns, ensure_list
 
 
 def __getattr__(name):
@@ -16,7 +16,7 @@ def __getattr__(name):
 
 __all__ = [
     "coalesce_common_columns",
-    "ensure_listlike",
+    "ensure_list",
     "get_us_loc_pop_tbl",
     "LOCATION_LIST",
     "arviz",

--- a/cfa/stf/forecasttools/utils.py
+++ b/cfa/stf/forecasttools/utils.py
@@ -1,31 +1,14 @@
-from collections.abc import MutableSequence
+from collections.abc import Iterable
 
 import polars as pl
 import polars.selectors as cs
 
 
-def ensure_listlike(x):
-    """
-    Ensure that an object either behaves like a
-    :class:`MutableSequence` and if not return a
-    one-item :class:`list` containing the object.
-    Useful for handling list-of-strings inputs
-    alongside single strings.
-    Based on this _`StackOverflow approach
-    <https://stackoverflow.com/a/66485952>`.
-
-    Parameters
-    ----------
-    x
-        The item to ensure is :class:`list`-like.
-    Returns
-    -------
-    MutableSequence
-        ``x`` if ``x`` is a :class:`MutableSequence`
-        otherwise ``[x]`` (i.e. a one-item list containing
-        ``x``.
-    """
-    return x if isinstance(x, MutableSequence) else [x]
+def ensure_listlike[T](x: T | Iterable[T]) -> list[T]:
+    if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
+        return list(x)
+    else:
+        return [x]
 
 
 def coalesce_common_columns(

--- a/cfa/stf/forecasttools/utils.py
+++ b/cfa/stf/forecasttools/utils.py
@@ -4,7 +4,7 @@ import polars as pl
 import polars.selectors as cs
 
 
-def ensure_listlike[T](x: T | Iterable[T]) -> list[T]:
+def ensure_list[T](x: T | Iterable[T]) -> list[T]:
     if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
         return list(x)
     else:

--- a/pipelines/utils/common_utils.py
+++ b/pipelines/utils/common_utils.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from pyrenew_multisignal.hew import PyrenewHEWParam, build_pyrenew_hew_model
 
-from cfa.stf.forecasttools import LOCATION_LIST, ensure_listlike
+from cfa.stf.forecasttools import LOCATION_LIST, ensure_list
 from pipelines.utils.cli_utils import run_command
 
 # Disease mapping and location abbreviations
@@ -579,7 +579,7 @@ def get_all_forecast_dirs(
     ValueError
         Given an invalid ``report_date``.
     """
-    diseases = ensure_listlike(diseases)
+    diseases = ensure_list(diseases)
 
     if report_date is None:
         report_date_str = ""


### PR DESCRIPTION
The previous version would incorrectly convert `('a', 'b')` to `[('a', 'b')]`, for example.