### PR TITLE
Make `disease` and `loc_abb` arguments in `get_nssp` and `get_nhsn_hrd` in `cfa.stf.data` more flexible

### DIFF
--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -1,8 +1,11 @@
 import datetime as dt
+from collections.abc import Iterable
 from typing import Literal, overload
 
 import polars as pl
 from cfa.dataops import datacat
+
+from cfa.stf.forecasttools import ensure_list
 
 nhsn_disease_map = {
     "COVID-19": "totalconfc19newadm",
@@ -114,31 +117,31 @@ def get_nhsn_hrd(
 
 @overload
 def get_nssp(
-    disease: str,
-    loc_abb: str,
-    dataset: NSSPDataset = ...,
-    as_of: dt.date | None = ...,
-    start_date: dt.date | None = ...,
-    end_date: dt.date | None = ...,
+    disease: str | Iterable[str] | None = None,
+    loc_abb: str | Iterable[str] | None = None,
+    dataset: NSSPDataset = "gold",
+    as_of: dt.date | None = None,
+    start_date: dt.date | None = None,
+    end_date: dt.date | None = None,
     lazy: Literal[True] = ...,
 ) -> pl.LazyFrame: ...
 
 
 @overload
 def get_nssp(
-    disease: str,
-    loc_abb: str,
-    dataset: NSSPDataset = ...,
-    as_of: dt.date | None = ...,
-    start_date: dt.date | None = ...,
-    end_date: dt.date | None = ...,
+    disease: str | Iterable[str] | None = None,
+    loc_abb: str | Iterable[str] | None = None,
+    dataset: NSSPDataset = "gold",
+    as_of: dt.date | None = None,
+    start_date: dt.date | None = None,
+    end_date: dt.date | None = None,
     lazy: Literal[False] = ...,
 ) -> pl.DataFrame: ...
 
 
 def get_nssp(
-    disease: str,
-    loc_abb: str,
+    disease: str | Iterable[str] | None = None,
+    loc_abb: str | Iterable[str] | None = None,
     dataset: NSSPDataset = "gold",
     as_of: dt.date | None = None,
     start_date: dt.date | None = None,
@@ -157,9 +160,9 @@ def get_nssp(
     Parameters
     ----------
     disease
-        The disease to filter for ("COVID-19", "Influenza", or "RSV").
+        The disease to filter for ("COVID-19", "Influenza", or "RSV"). If None, all diseases are included.
     loc_abb
-        Location abbreviation to filter for.
+        Location abbreviation to filter for. If None, all locations are included.
     dataset
         One of the two datasets to retrieve from datacat: "gold" or
         "comprehensive" (defaults to "gold").
@@ -194,18 +197,60 @@ def get_nssp(
     if as_of is None:
         as_of = dt.date.max
 
+    output = "pl_lazy" if lazy else "pl"
+
     dataset_map = {
         "gold": datacat.public.stf.nssp_gold_v1,
         "comprehensive": datacat.public.stf.comprehensive_nssp_gold,
     }
+
     if dataset not in dataset_map:
         raise ValueError(
             f"Invalid dataset: {dataset!r}. Expected one of: {set(dataset_map)}."
         )
     datacat_dataset = dataset_map[dataset]
 
+    dat = datacat_dataset.load.get_dataframe(
+        output=output, version=f"<={as_of.strftime('%Y-%m-%d')}"
+    ).with_columns(
+        pl.col("disease").cast(pl.String).replace("COVID-19/Omicron", "COVID-19")
+    )
+
+    valid_locs = (
+        dat.select("geo_value").unique().collect()
+        if lazy
+        else dat.select("geo_value").unique()
+    ).get_column("geo_value").sort().to_list() + ["US"]
+
+    loc_abb = ensure_list(loc_abb) if loc_abb else valid_locs
+
+    US_required = "US" in loc_abb
+    non_US_locs = [loc for loc in loc_abb if loc != "US"]
+
+    invalid_locs = set(non_US_locs) - set(valid_locs)
+    if invalid_locs:
+        raise ValueError(f"Invalid location abbreviation(s): {invalid_locs}")
+
+    valid_diseases = (
+        (
+            dat.select("disease").unique().collect()
+            if lazy
+            else dat.select("disease").unique()
+        )
+        .get_column("disease")
+        .to_list()
+    )
+    disease = ensure_list(disease) if disease else valid_diseases
+
+    if "Total" not in disease:
+        disease.append("Total")
+
+    invalid_diseases = set(disease) - set(valid_diseases)
+    if invalid_diseases:
+        raise ValueError(f"Invalid disease(s): {invalid_diseases}")
+
     filters = [
-        pl.col("disease").is_in([disease, "Total"]),
+        pl.col("disease").is_in(disease),
         pl.col("metric") == "count_ed_visits",
     ]
 
@@ -213,34 +258,28 @@ def get_nssp(
         filters.append(pl.col("reference_date") >= start_date)
     if end_date is not None:
         filters.append(pl.col("reference_date") <= end_date)
-    if loc_abb != "US":
-        # National-level data (loc_abb == "US"), is obtained
-        # by aggregating state-level data. Therefore,
-        # we only filter by geo_value if loc_abb is not "US".
-        filters.append(pl.col("geo_value") == loc_abb)
 
-    output = "pl_lazy" if lazy else "pl"
-    dat = datacat_dataset.load.get_dataframe(
-        output=output, version=f"<={as_of.strftime('%Y-%m-%d')}"
+    dat = dat.filter(*filters)
+
+    non_US_dat = dat.filter(pl.col("geo_value").is_in(non_US_locs))
+
+    combined_dat = (
+        pl.concat(
+            [
+                non_US_dat,
+                dat.with_columns(pl.lit("US").alias("geo_value").cast(pl.Categorical)),
+            ]
+        )
+        if US_required
+        else non_US_dat
     )
 
-    valid_locs = (
-        dat.select("geo_value").unique().collect()
-        if lazy
-        else dat.select("geo_value").unique()
-    ).get_column("geo_value").to_list() + ["US"]
-
-    if loc_abb not in valid_locs:
-        raise ValueError(f"Invalid location abbreviation: {loc_abb}")
-
-    dat_filtered = dat.with_columns(
-        pl.col("disease").cast(pl.String).replace("COVID-19/Omicron", "COVID-19")
-    ).filter(*filters)
-
     result = (
-        dat_filtered.group_by("reference_date", "disease")
+        combined_dat.group_by("reference_date", "disease", "geo_value")
         .agg(pl.col("value").sum())
-        .sort("reference_date")
+        .sort(
+            ["geo_value", "disease", "reference_date"], descending=[False, False, True]
+        )
     )
 
     return result

--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import warnings
 from collections.abc import Iterable
 from typing import Literal, overload
 
@@ -198,78 +199,57 @@ def get_nssp(
     if as_of is None:
         as_of = dt.date.max
 
-    output = "pl_lazy" if lazy else "pl"
+    loc_abb = ensure_list(loc_abb)
+    all_locs = not loc_abb
+
+    disease = ensure_list(disease)
+    all_diseases = not disease
 
     dataset_map = {
         "gold": datacat.public.stf.nssp_gold_v1,
         "comprehensive": datacat.public.stf.comprehensive_nssp_gold,
     }
 
-    if dataset not in dataset_map:
+    if not (datacat_dataset := dataset_map.get(dataset)):
         raise ValueError(
-            f"Invalid dataset: {dataset!r}. Expected one of: {set(dataset_map)}."
+            f"Invalid dataset: {dataset!r}. Expected one of: {set(dataset_map)!r}."
         )
-    datacat_dataset = dataset_map[dataset]
 
-    dat = datacat_dataset.load.get_dataframe(
-        output=output, version=f"<={as_of.strftime('%Y-%m-%d')}"
-    ).with_columns(
-        pl.col("disease").cast(pl.String).replace("COVID-19/Omicron", "COVID-19")
-    )
-
-    valid_locs = (
-        dat.select("geo_value").unique().collect()
-        if lazy
-        else dat.select("geo_value").unique()
-    ).get_column("geo_value").sort().to_list() + ["US"]
-
-    loc_abb = ensure_list(loc_abb) if loc_abb else valid_locs
-
-    US_required = "US" in loc_abb
-    non_US_locs = [loc for loc in loc_abb if loc != "US"]
-
-    invalid_locs = set(non_US_locs) - set(valid_locs)
-    if invalid_locs:
-        raise ValueError(f"Invalid location abbreviation(s): {invalid_locs}")
-
-    valid_diseases = (
-        (
-            dat.select("disease").unique().collect()
-            if lazy
-            else dat.select("disease").unique()
-        )
-        .get_column("disease")
-        .to_list()
-    )
-    disease = ensure_list(disease) if disease else valid_diseases
-
-    invalid_diseases = set(disease) - set(valid_diseases)
-    if invalid_diseases:
-        raise ValueError(f"Invalid disease(s): {invalid_diseases}")
+    US_required = all_locs or "US" in loc_abb
 
     filters = [
-        pl.col("disease").is_in(disease),
         pl.col("metric") == "count_ed_visits",
     ]
 
-    if start_date is not None:
+    if not all_diseases:
+        filters.append(pl.col("disease").is_in(disease))
+    if start_date:
         filters.append(pl.col("reference_date") >= start_date)
-    if end_date is not None:
+    if end_date:
         filters.append(pl.col("reference_date") <= end_date)
 
-    dat = dat.filter(*filters)
+    dat = (
+        datacat_dataset.load.get_dataframe(
+            output="lazy", version=f"<={as_of.strftime('%Y-%m-%d')}"
+        )
+        .with_columns(
+            pl.col("disease").cast(pl.String).replace("COVID-19/Omicron", "COVID-19")
+        )
+        .filter(*filters)
+    )
 
-    non_US_dat = dat.filter(pl.col("geo_value").is_in(non_US_locs))
+    state_locs = [loc for loc in loc_abb if loc != "US"]
+    state_dat = dat if all_locs else dat.filter(pl.col("geo_value").is_in(state_locs))
 
     combined_dat = (
         pl.concat(
             [
-                non_US_dat,
+                state_dat,
                 dat.with_columns(pl.lit("US").alias("geo_value").cast(pl.Categorical)),
             ]
         )
         if US_required
-        else non_US_dat
+        else state_dat
     )
 
     result = (
@@ -280,4 +260,24 @@ def get_nssp(
         )
     )
 
+    if not all_diseases:
+        result_disease = (
+            result.unique("disease").collect().get_column("disease").to_list()
+        )
+        missing_diseases = set(disease) - set(result_disease)
+        if missing_diseases:
+            warnings.warn(
+                f"Requested diseases {missing_diseases} not found in results."
+            )
+
+    if not all_locs:
+        result_loc_abbr = (
+            result.unique("geo_value").collect().get_column("geo_value").to_list()
+        )
+        missing_locs = set(loc_abb) - set(result_loc_abbr)
+        if missing_locs:
+            warnings.warn(f"Requested locations {missing_locs} not found in results.")
+
+    if not lazy:
+        result = result.collect()
     return result

--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -8,12 +8,6 @@ from cfa.dataops import datacat
 
 from cfa.stf.forecasttools import ensure_list
 
-nhsn_disease_map = {
-    "COVID-19": "totalconfc19newadm",
-    "Influenza": "totalconfflunewadm",
-    "RSV": "totalconfrsvnewadm",
-}
-
 NSSPDataset = Literal["gold", "comprehensive"]
 
 
@@ -81,40 +75,71 @@ def get_nhsn_hrd(
         Filtered data with columns:
         `weekendingdate`, `jurisdiction`, and `hospital_admissions`.
     """
-    if as_of is None:
+    if not as_of:
         as_of = dt.date.max
 
-    disease = ensure_list(disease) if disease else list(nhsn_disease_map.keys())
+    disease = ensure_list(disease)
+    all_diseases = not disease
 
-    disease_col = [nhsn_disease_map[x] for x in disease]
-    loc_abb = ensure_list(loc_abb) if loc_abb else None
+    loc_abb = ensure_list(loc_abb)
+    all_locs = not loc_abb
+
+    nhsn_disease_map = {
+        "COVID-19": "totalconfc19newadm",
+        "Influenza": "totalconfflunewadm",
+        "RSV": "totalconfrsvnewadm",
+    }
+
+    disease_valid = (
+        list(nhsn_disease_map.keys())
+        if all_diseases
+        else [x for x in disease if x in nhsn_disease_map.keys()]
+    )
+
+    raw_disease_col = [nhsn_disease_map.get(x) for x in disease_valid]
+
+    inv_nhsn_disease_map = {nhsn_disease_map.get(x): x for x in disease_valid}
 
     filters = []
-    if loc_abb is not None:
+    if not all_locs:
         filters.append(pl.col("jurisdiction").is_in(loc_abb))
-    if start_date is not None:
+    if start_date:
         filters.append(pl.col("weekendingdate") >= start_date)
-    if end_date is not None:
+    if end_date:
         filters.append(pl.col("weekendingdate") <= end_date)
 
     datacat_dataset = (
         datacat.public.stf.nhsn_hrd_prelim if prelim else datacat.public.stf.nhsn_hrd
     )
 
-    output = "pl_lazy" if lazy else "pl"
-    dat = datacat_dataset.load.get_dataframe(
-        output=output, version=f"<={as_of.strftime('%Y-%m-%d')}"
-    )
-
-    filtered_dat = (
-        dat.with_columns(pl.col("jurisdiction").cast(pl.String).replace("USA", "US"))
+    dat = (
+        datacat_dataset.load.get_dataframe(
+            output="lazy", version=f"<={as_of.strftime('%Y-%m-%d')}"
+        )
+        .select(raw_disease_col + ["weekendingdate", "jurisdiction"])
+        .with_columns(
+            pl.col("jurisdiction").replace_strict(
+                {"USA": "US"}, default=pl.col("jurisdiction")
+            )
+        )
         .filter(*filters)
-        .select(disease_col + ["weekendingdate", "jurisdiction"])
+        .rename(inv_nhsn_disease_map)
+        .unpivot(
+            on=disease_valid,
+            index=["weekendingdate", "jurisdiction"],
+            variable_name="disease",
+            value_name="hospital_admissions",
+        )
+        .sort(
+            ["jurisdiction", "disease", "weekendingdate"],
+            descending=[False, False, True],
+        )
     )
-    # need to pivot and add a new column for disease name
+    # check if we got everything that was created
 
-    # .alias("hospital_admissions")
-    return filtered_dat
+    if not lazy:
+        dat = dat.collect()
+    return dat
 
 
 @overload

--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -135,7 +135,21 @@ def get_nhsn_hrd(
             descending=[False, False, True],
         )
     )
-    # check if we got everything that was created
+
+    if not all_diseases:
+        result_disease = dat.unique("disease").collect().get_column("disease").to_list()
+        missing_diseases = set(disease) - set(result_disease)
+        if missing_diseases:
+            warnings.warn(
+                f"Requested diseases {missing_diseases} not found in results."
+            )
+    if not all_locs:
+        result_loc_abbr = (
+            dat.unique("jurisdiction").collect().get_column("jurisdiction").to_list()
+        )
+        missing_locs = set(loc_abb) - set(result_loc_abbr)
+        if missing_locs:
+            warnings.warn(f"Requested locations {missing_locs} not found in results.")
 
     if not lazy:
         dat = dat.collect()

--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -72,8 +72,8 @@ def get_nhsn_hrd(
     Returns
     -------
     pl.DataFrame | pl.LazyFrame
-        Filtered data with columns:
-        `weekendingdate`, `jurisdiction`, and `hospital_admissions`.
+        Filtered data in long format with columns:
+        `weekendingdate`, `jurisdiction`, `disease`, and `hospital_admissions`.
     """
     if not as_of:
         as_of = dt.date.max

--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -114,7 +114,7 @@ def get_nhsn_hrd(
 
     dat = (
         datacat_dataset.load.get_dataframe(
-            output="lazy", version=f"<={as_of.strftime('%Y-%m-%d')}"
+            output="pl_lazy", version=f"<={as_of.strftime('%Y-%m-%d')}"
         )
         .select(raw_disease_col + ["weekendingdate", "jurisdiction"])
         .with_columns(
@@ -267,7 +267,7 @@ def get_nssp(
 
     dat = (
         datacat_dataset.load.get_dataframe(
-            output="lazy", version=f"<={as_of.strftime('%Y-%m-%d')}"
+            output="pl_lazy", version=f"<={as_of.strftime('%Y-%m-%d')}"
         )
         .with_columns(
             pl.col("disease").cast(pl.String).replace("COVID-19/Omicron", "COVID-19")

--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -79,10 +79,10 @@ def get_nhsn_hrd(
         as_of = dt.date.max
 
     disease = ensure_list(disease)
-    all_diseases = not disease
+    get_all_diseases = not disease
 
     loc_abb = ensure_list(loc_abb)
-    all_locs = not loc_abb
+    get_all_locs = not loc_abb
 
     nhsn_disease_map = {
         "COVID-19": "totalconfc19newadm",
@@ -92,7 +92,7 @@ def get_nhsn_hrd(
 
     disease_valid = (
         list(nhsn_disease_map.keys())
-        if all_diseases
+        if get_all_diseases
         else [x for x in disease if x in nhsn_disease_map.keys()]
     )
 
@@ -101,7 +101,7 @@ def get_nhsn_hrd(
     inv_nhsn_disease_map = {nhsn_disease_map.get(x): x for x in disease_valid}
 
     filters = []
-    if not all_locs:
+    if not get_all_locs:
         filters.append(pl.col("jurisdiction").is_in(loc_abb))
     if start_date:
         filters.append(pl.col("weekendingdate") >= start_date)
@@ -136,13 +136,13 @@ def get_nhsn_hrd(
         )
     )
 
-    if not all_diseases:
+    if not get_all_diseases:
         result_disease = dat.unique("disease").collect().get_column("disease").to_list()
         if missing_diseases := set(disease) - set(result_disease):
             warnings.warn(
                 f"Requested diseases {missing_diseases} not found in results."
             )
-    if not all_locs:
+    if not get_all_locs:
         result_loc_abbr = (
             dat.unique("jurisdiction").collect().get_column("jurisdiction").to_list()
         )
@@ -237,10 +237,10 @@ def get_nssp(
         as_of = dt.date.max
 
     loc_abb = ensure_list(loc_abb)
-    all_locs = not loc_abb
+    get_all_locs = not loc_abb
 
     disease = ensure_list(disease)
-    all_diseases = not disease
+    get_all_diseases = not disease
 
     dataset_map = {
         "gold": datacat.public.stf.nssp_gold_v1,
@@ -252,13 +252,13 @@ def get_nssp(
             f"Invalid dataset: {dataset!r}. Expected one of: {set(dataset_map)!r}."
         )
 
-    national_required = all_locs or "US" in loc_abb
+    national_required = get_all_locs or "US" in loc_abb
 
     filters = [
         pl.col("metric") == "count_ed_visits",
     ]
 
-    if not all_diseases:
+    if not get_all_diseases:
         filters.append(pl.col("disease").is_in(disease))
     if start_date:
         filters.append(pl.col("reference_date") >= start_date)
@@ -276,7 +276,9 @@ def get_nssp(
     )
 
     state_locs = [loc for loc in loc_abb if loc != "US"]
-    state_dat = dat if all_locs else dat.filter(pl.col("geo_value").is_in(state_locs))
+    state_dat = (
+        dat if get_all_locs else dat.filter(pl.col("geo_value").is_in(state_locs))
+    )
 
     combined_dat = (
         pl.concat(
@@ -297,7 +299,7 @@ def get_nssp(
         )
     )
 
-    if not all_diseases:
+    if not get_all_diseases:
         result_disease = (
             result.unique("disease").collect().get_column("disease").to_list()
         )
@@ -306,7 +308,7 @@ def get_nssp(
                 f"Requested diseases {missing_diseases} not found in results."
             )
 
-    if not all_locs:
+    if not get_all_locs:
         result_loc_abbr = (
             result.unique("geo_value").collect().get_column("geo_value").to_list()
         )

--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -138,8 +138,7 @@ def get_nhsn_hrd(
 
     if not all_diseases:
         result_disease = dat.unique("disease").collect().get_column("disease").to_list()
-        missing_diseases = set(disease) - set(result_disease)
-        if missing_diseases:
+        if missing_diseases := set(disease) - set(result_disease):
             warnings.warn(
                 f"Requested diseases {missing_diseases} not found in results."
             )
@@ -147,8 +146,7 @@ def get_nhsn_hrd(
         result_loc_abbr = (
             dat.unique("jurisdiction").collect().get_column("jurisdiction").to_list()
         )
-        missing_locs = set(loc_abb) - set(result_loc_abbr)
-        if missing_locs:
+        if missing_locs := set(loc_abb) - set(result_loc_abbr):
             warnings.warn(f"Requested locations {missing_locs} not found in results.")
 
     if not lazy:
@@ -303,8 +301,7 @@ def get_nssp(
         result_disease = (
             result.unique("disease").collect().get_column("disease").to_list()
         )
-        missing_diseases = set(disease) - set(result_disease)
-        if missing_diseases:
+        if missing_diseases := set(disease) - set(result_disease):
             warnings.warn(
                 f"Requested diseases {missing_diseases} not found in results."
             )
@@ -313,8 +310,7 @@ def get_nssp(
         result_loc_abbr = (
             result.unique("geo_value").collect().get_column("geo_value").to_list()
         )
-        missing_locs = set(loc_abb) - set(result_loc_abbr)
-        if missing_locs:
+        if missing_locs := set(loc_abb) - set(result_loc_abbr):
             warnings.warn(f"Requested locations {missing_locs} not found in results.")
 
     if not lazy:

--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -215,7 +215,7 @@ def get_nssp(
             f"Invalid dataset: {dataset!r}. Expected one of: {set(dataset_map)!r}."
         )
 
-    US_required = all_locs or "US" in loc_abb
+    national_required = all_locs or "US" in loc_abb
 
     filters = [
         pl.col("metric") == "count_ed_visits",
@@ -248,7 +248,7 @@ def get_nssp(
                 dat.with_columns(pl.lit("US").alias("geo_value").cast(pl.Categorical)),
             ]
         )
-        if US_required
+        if national_required
         else state_dat
     )
 

--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -161,7 +161,7 @@ def get_nssp(
     Parameters
     ----------
     disease
-        The disease to filter for ("COVID-19", "Influenza", or "RSV"). If None, all diseases are included.
+        The disease to filter for ("COVID-19", "Influenza", "RSV", or "Total"). If None, all diseases are included.
     loc_abb
         Location abbreviation to filter for. If None, all locations are included.
     dataset
@@ -242,9 +242,6 @@ def get_nssp(
         .to_list()
     )
     disease = ensure_list(disease) if disease else valid_diseases
-
-    if "Total" not in disease:
-        disease.append("Total")
 
     invalid_diseases = set(disease) - set(valid_diseases)
     if invalid_diseases:

--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -220,13 +220,7 @@ def get_nssp(
     -------
     pl.DataFrame | pl.LazyFrame
         Aggregated ED counts with columns:
-        `reference_date`, `disease`, and `value`.
-
-    Raises
-    ------
-    ValueError
-        If the specified dataset is invalid or the specified location
-        abbreviation is not found in the data.
+        `reference_date`, `disease`, `geo_value`, and `value`.
 
     Notes
     -----

--- a/cfa/stf/data/get_data.py
+++ b/cfa/stf/data/get_data.py
@@ -18,8 +18,8 @@ NSSPDataset = Literal["gold", "comprehensive"]
 
 @overload
 def get_nhsn_hrd(
-    disease: str,
-    loc_abb: str,
+    disease: str | Iterable[str] | None = None,
+    loc_abb: str | Iterable[str] | None = None,
     prelim: bool = ...,
     as_of: dt.date | None = ...,
     start_date: dt.date | None = ...,
@@ -30,8 +30,8 @@ def get_nhsn_hrd(
 
 @overload
 def get_nhsn_hrd(
-    disease: str,
-    loc_abb: str,
+    disease: str | Iterable[str] | None = None,
+    loc_abb: str | Iterable[str] | None = None,
     prelim: bool = ...,
     as_of: dt.date | None = ...,
     start_date: dt.date | None = ...,
@@ -41,8 +41,8 @@ def get_nhsn_hrd(
 
 
 def get_nhsn_hrd(
-    disease: str,
-    loc_abb: str,
+    disease: str | Iterable[str] | None = None,
+    loc_abb: str | Iterable[str] | None = None,
     prelim: bool = True,
     as_of: dt.date | None = None,
     start_date: dt.date | None = None,
@@ -59,9 +59,9 @@ def get_nhsn_hrd(
     Parameters
     ----------
     disease
-        The disease to filter for ("COVID-19", "Influenza", or "RSV").
+        The disease to filter for ("COVID-19", "Influenza", or "RSV"). If None, all diseases are included.
     loc_abb
-        The location abbreviation to filter for.
+        The location abbreviation to filter for. If None, all locations are included.
     prelim
         Whether to retrieve "nhsn_hrd_prelim" data as opposed to "nhsn_hrd" data (defaults to True).
     as_of
@@ -80,19 +80,21 @@ def get_nhsn_hrd(
         Filtered data with columns:
         `weekendingdate`, `jurisdiction`, and `hospital_admissions`.
     """
+    if as_of is None:
+        as_of = dt.date.max
 
-    disease_col = nhsn_disease_map[disease]
+    disease = ensure_list(disease) if disease else list(nhsn_disease_map.keys())
 
-    filters = [
-        pl.col("jurisdiction") == loc_abb,
-    ]
+    disease_col = [nhsn_disease_map[x] for x in disease]
+    loc_abb = ensure_list(loc_abb) if loc_abb else None
+
+    filters = []
+    if loc_abb is not None:
+        filters.append(pl.col("jurisdiction").is_in(loc_abb))
     if start_date is not None:
         filters.append(pl.col("weekendingdate") >= start_date)
     if end_date is not None:
         filters.append(pl.col("weekendingdate") <= end_date)
-
-    if as_of is None:
-        as_of = dt.date.max
 
     datacat_dataset = (
         datacat.public.stf.nhsn_hrd_prelim if prelim else datacat.public.stf.nhsn_hrd
@@ -106,12 +108,11 @@ def get_nhsn_hrd(
     filtered_dat = (
         dat.with_columns(pl.col("jurisdiction").cast(pl.String).replace("USA", "US"))
         .filter(*filters)
-        .select(
-            "weekendingdate",
-            "jurisdiction",
-            pl.col(disease_col).alias("hospital_admissions"),
-        )
+        .select(disease_col + ["weekendingdate", "jurisdiction"])
     )
+    # need to pivot and add a new column for disease name
+
+    # .alias("hospital_admissions")
     return filtered_dat
 
 

--- a/cfa/stf/forecasttools/utils.py
+++ b/cfa/stf/forecasttools/utils.py
@@ -1,10 +1,19 @@
 from collections.abc import Iterable
+from typing import overload
 
 import polars as pl
 import polars.selectors as cs
 
 
-def ensure_list[T](x: T | Iterable[T]) -> list[T]:
+@overload
+def ensure_list[T](x: None) -> None: ...
+
+
+@overload
+def ensure_list[T](x: T | Iterable[T]) -> list[T]: ...
+
+
+def ensure_list[T](x: T | Iterable[T] | None) -> list[T] | None:
     if x is None:
         return []
     elif isinstance(x, Iterable) and not isinstance(x, (str, bytes)):

--- a/cfa/stf/forecasttools/utils.py
+++ b/cfa/stf/forecasttools/utils.py
@@ -5,7 +5,9 @@ import polars.selectors as cs
 
 
 def ensure_list[T](x: T | Iterable[T]) -> list[T]:
-    if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
+    if x is None:
+        return []
+    elif isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
         return list(x)
     else:
         return [x]


### PR DESCRIPTION
Closes https://github.com/CDCgov/cfa-stf-routine-forecasting/issues/1001

Still mulling over ideas for testing this module, but this all works as expected in the ext environment:

```python
from cfa.stf.data.get_data import get_nhsn_hrd, get_nssp

all_all = get_nssp(lazy=False)
all_all.unique("geo_value").get_column("geo_value")
all_all.unique("disease").get_column("disease")

US_all = get_nssp(loc_abb = "US", lazy=False)
US_all.unique("geo_value").get_column("geo_value")
US_all.unique("disease").get_column("disease")

AK_all = get_nssp(loc_abb = "AK", lazy=False)
AK_all.unique("geo_value").get_column("geo_value")
AK_all.unique("disease").get_column("disease")

AKCA_all = get_nssp(loc_abb = ["AK", "CA"], lazy=False)
AKCA_all.unique("geo_value").get_column("geo_value")
AKCA_all.unique("disease").get_column("disease")

CAUS_all = get_nssp(loc_abb = ["CA", "US"], lazy=False)
CAUS_all.unique("geo_value").get_column("geo_value")
CAUS_all.unique("disease").get_column("disease")

xyzz = get_nssp(
    loc_abb=["CA", "US", "XY"], disease=["COVID-19", "Influenza", "ZZ"], lazy=False
)
xyzz.unique("geo_value").get_column("geo_value")
xyzz.unique("disease").get_column("disease")

xyzz_nhsn = get_nhsn_hrd(
    loc_abb=["CA", "US", "XY"], disease=["COVID-19", "Influenza", "ZZ"], lazy=False
)

xyzz_nhsn.unique("jurisdiction").get_column("jurisdiction")
xyzz_nhsn.unique("disease").get_column("disease")


cac19_nhsn = get_nhsn_hrd(loc_abb="CA", disease="COVID-19", lazy=False)
cac19_nhsn.unique("jurisdiction").get_column("jurisdiction")
cac19_nhsn.unique("disease").get_column("disease")

all_all_nhsn = get_nhsn_hrd(lazy=False)
all_all_nhsn.unique("jurisdiction").get_column("jurisdiction")
all_all_nhsn.unique("disease").get_column("disease")
````