### PR TITLE
Fix issue 1062: update interop tests

### DIFF
--- a/EpiAutoGP/src/output.jl
+++ b/EpiAutoGP/src/output.jl
@@ -110,7 +110,7 @@ function create_forecast_df(results::NamedTuple, output_type::PipelineOutput)
         DataFrame(
             :date => forecast_dates,
             Symbol(".value") => sampled_values,
-            Symbol(".draw") => fill(draw, length(sampled_values))
+            Symbol(".draw") => fill(Int32(draw), length(sampled_values))
         )
     end
 

--- a/EpiAutoGP/test/test_output.jl
+++ b/EpiAutoGP/test/test_output.jl
@@ -107,6 +107,7 @@ end
             parquet_path = joinpath(tmpdir, "samples.parquet")
             @test isfile(parquet_path)
             @test eltype(result_df.date) == Date
+            @test eltype(result_df[!, Symbol(".draw")]) == Int32
             @test propertynames(result_df) == [
                 :date,
                 Symbol(".value"),
@@ -127,6 +128,7 @@ end
                 )
 
                 @test eltype(read_df.date) == Date
+                @test eltype(read_df[!, Symbol(".draw")]) <: Integer
                 @test propertynames(read_df) == propertynames(result_df)
                 @test read_df.date == forecast_dates[[1, 2, 1, 2]]
                 @test read_df[!, Symbol(".draw")] == [1, 1, 2, 2]

--- a/pipelines/tests/test_epiautogp_parquet_interop.py
+++ b/pipelines/tests/test_epiautogp_parquet_interop.py
@@ -1,14 +1,40 @@
-"""Cross-language checks for EpiAutoGP samples parquet output."""
+"""Cross-language checks for EpiAutoGP parquet output.
+
+This module guards the schema boundary that failed in pipeline-run-check
+postprocessing: EpiAutoGP wrote samples through Julia/DuckDB, R converted each
+model's samples to a hubverse table, and Python/Polars combined those hubverse
+tables across model directories. The failure was caused by one producer writing
+draw IDs as floats while the rest wrote integer sample identifiers.
+Those draw IDs are `.draw` in `samples.parquet`; the hubverse conversion renames
+them to `output_type_id`, which is where the CI failure surfaced.
+
+The fixtures intentionally do not run full forecasting models. Instead, they
+build tiny but realistic model-fit directories for each producer family:
+EpiAutoGP samples from Julia, fable-style samples from R, and PyRenew-style
+posterior predictive output from Python that is converted by the real PyRenew R
+sample conversion script. The final test then runs the same hubverse conversion
+and batch combine functions used by CI so producer schema drift is caught before
+postprocessing reaches the expensive end-to-end workflow.
+"""
 
 import datetime as dt
 import json
+import shutil
 import textwrap
+from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 
 import polars as pl
 import pytest
 
-from pipelines.utils.common_utils import run_julia_code, run_r_code
+from pipelines.utils.common_utils import (
+    model_fit_dir_to_hub_tbl,
+    run_julia_code,
+    run_r_code,
+    run_r_script,
+)
+from pipelines.utils.postprocess_forecast_batches import combine_hubverse_tables
 
 EXPECTED_DATES = [
     dt.date(2024, 2, 4),
@@ -16,6 +42,14 @@ EXPECTED_DATES = [
     dt.date(2024, 2, 4),
     dt.date(2024, 2, 10),
 ]
+EXPECTED_DRAWS = [1, 1, 2, 2]
+
+
+@dataclass(frozen=True)
+class EpiAutoGPInteropPaths:
+    batch_dir: Path
+    model_fit_dir: Path
+    samples_path: Path
 
 
 def _quote_for_embedded_code(value: str | Path) -> str:
@@ -41,84 +75,148 @@ def _skip_if_r_packages_missing(*packages: str) -> None:
 
 
 @pytest.fixture(scope="module")
-def epiautogp_samples_path(tmp_path_factory) -> Path:
-    model_fit_dir = (
-        tmp_path_factory.mktemp("epiautogp-parquet-interop")
-        / "covid-19_r_2024-02-03_f_2024-01-01_t_2024-02-01"
-        / "model_runs"
-        / "US"
-        / "epiautogp_nhsn_epiweekly"
-    )
-    forecast_dates = list(dict.fromkeys(EXPECTED_DATES))
-    assert len(EXPECTED_DATES) % len(forecast_dates) == 0
-    draw_count = len(EXPECTED_DATES) // len(forecast_dates)
-    assert EXPECTED_DATES == forecast_dates * draw_count
+def epiautogp_interop_paths(tmp_path_factory) -> Iterator[EpiAutoGPInteropPaths]:
+    tmp_dir = tmp_path_factory.mktemp("epiautogp-parquet-interop")
+    try:
+        batch_dir = tmp_dir / "covid-19_r_2024-02-03_f_2024-01-01_t_2024-02-01"
+        model_fit_dir = batch_dir / "model_runs" / "US" / "epiautogp_nhsn_epiweekly"
+        forecast_dates = list(dict.fromkeys(EXPECTED_DATES))
+        assert len(EXPECTED_DATES) % len(forecast_dates) == 0
+        draw_count = len(EXPECTED_DATES) // len(forecast_dates)
+        assert EXPECTED_DATES == forecast_dates * draw_count
 
-    forecast_dates_julia = ", ".join(
-        f'Date("{forecast_date.isoformat()}")' for forecast_date in forecast_dates
-    )
-    forecasts_julia = "; ".join(
-        " ".join(
-            str(float(100 * (date_index + 1) + draw_index + 1))
-            for draw_index in range(draw_count)
+        forecast_dates_julia = ", ".join(
+            f'Date("{forecast_date.isoformat()}")' for forecast_date in forecast_dates
         )
-        for date_index in range(len(forecast_dates))
-    )
-    julia_code = textwrap.dedent(
+        forecasts_julia = "; ".join(
+            " ".join(
+                str(float(100 * (date_index + 1) + draw_index + 1))
+                for draw_index in range(draw_count)
+            )
+            for date_index in range(len(forecast_dates))
+        )
+        julia_code = textwrap.dedent(
+            f"""
+            using Dates
+            using EpiAutoGP
+
+            input = EpiAutoGPInput(
+                [Date("2024-01-01")],
+                [100.0],
+                "COVID-19",
+                "US",
+                "nhsn",
+                "epiweekly",
+                "observed",
+                Date("2024-02-03"),
+                Date[],
+                Vector{{Real}}[]
+            )
+            results = (
+                forecast_dates = [{forecast_dates_julia}],
+                forecasts = [{forecasts_julia}],
+            )
+
+            create_forecast_output(
+                input,
+                results,
+                {_quote_for_embedded_code(model_fit_dir)},
+                PipelineOutput();
+                save_output = true
+            )
+            """
+        )
+        try:
+            run_julia_code(
+                julia_code,
+                executor_flags=["--project=EpiAutoGP", "--startup-file=no"],
+                text=True,
+            )
+        except FileNotFoundError:
+            pytest.skip("julia is not available")
+
+        samples_path = model_fit_dir / "samples.parquet"
+        assert samples_path.is_file()
+        yield EpiAutoGPInteropPaths(
+            batch_dir=batch_dir,
+            model_fit_dir=model_fit_dir,
+            samples_path=samples_path,
+        )
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def _write_fable_reference_model_samples(batch_dir: Path) -> Path:
+    fable_model_fit_dir = batch_dir / "model_runs" / "US" / "fable_daily"
+    r_code = textwrap.dedent(
         f"""
-        using Dates
-        using EpiAutoGP
+        library(dplyr)
+        library(forecasttools)
+        library(fs)
+        library(hewr)
 
-        input = EpiAutoGPInput(
-            [Date("2024-01-01")],
-            [100.0],
-            "COVID-19",
-            "US",
-            "nhsn",
-            "epiweekly",
-            "observed",
-            Date("2024-02-03"),
-            Date[],
-            Vector{{Real}}[]
-        )
-        results = (
-            forecast_dates = [{forecast_dates_julia}],
-            forecasts = [{forecasts_julia}],
-        )
+        fable_model_fit_dir <- {_quote_for_embedded_code(fable_model_fit_dir)}
+        dir_create(fable_model_fit_dir, recurse = TRUE)
 
-        create_forecast_output(
-            input,
-            results,
-            {_quote_for_embedded_code(model_fit_dir)},
-            PipelineOutput();
-            save_output = true
+        dates <- as.Date(c("2024-02-04", "2024-02-10", "2024-02-04", "2024-02-10"))
+        draws <- as.integer(c(1, 1, 2, 2))
+
+        fable_samples <- tibble::tibble(
+          date = dates,
+          .draw = draws,
+          observed_ed_visits = c(101, 201, 102, 202),
+          other_ed_visits = c(1001, 2001, 1002, 2002)
+        ) |>
+          hewr::format_timeseries_output(
+            geo_value = "US",
+            disease = "COVID-19",
+            resolution = "daily",
+            output_type_id = ".draw"
+          )
+        forecasttools::write_tabular(
+          fable_samples,
+          fs::path(fable_model_fit_dir, "samples", ext = "parquet")
         )
         """
     )
-    try:
-        run_julia_code(
-            julia_code,
-            executor_flags=["--project=EpiAutoGP", "--startup-file=no"],
-            text=True,
-        )
-    except FileNotFoundError:
-        pytest.skip("julia is not available")
+    run_r_code(r_code, executor_flags=["--vanilla"], text=True)
+    return fable_model_fit_dir
 
-    samples_path = model_fit_dir / "samples.parquet"
-    assert samples_path.is_file()
-    return samples_path
+
+def _write_pyrenew_reference_model_samples(batch_dir: Path) -> Path:
+    pyrenew_model_fit_dir = batch_dir / "model_runs" / "US" / "pyrenew_e"
+    mcmc_output_dir = pyrenew_model_fit_dir / "mcmc_output"
+    mcmc_output_dir.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(
+        {
+            "chain": [0, 0, 0, 0],
+            "draw": [0, 0, 1, 1],
+            "variable": ["observed_ed_visits"] * len(EXPECTED_DATES),
+            "value": [101.0, 201.0, 102.0, 202.0],
+            "date": EXPECTED_DATES,
+        }
+    ).write_parquet(mcmc_output_dir / "tidy_posterior_predictive.parquet")
+
+    run_r_script(
+        "pipelines/pyrenew_hew/create_samples_from_pyrenew_fit_dir.R",
+        [str(pyrenew_model_fit_dir)],
+        function_name="create_samples_from_pyrenew_fit_dir",
+    )
+    return pyrenew_model_fit_dir
 
 
 def test_epiautogp_samples_parquet_date_is_discovered_by_polars(
-    epiautogp_samples_path,
+    epiautogp_interop_paths,
 ):
-    samples = pl.read_parquet(epiautogp_samples_path)
+    samples = pl.read_parquet(epiautogp_interop_paths.samples_path)
 
     assert samples.schema["date"] == pl.Date
+    assert samples.schema[".draw"] == pl.Int32
     assert samples["date"].to_list() == EXPECTED_DATES
+    assert samples[".draw"].to_list() == EXPECTED_DRAWS
 
     lazy_schema = (
-        pl.scan_parquet(epiautogp_samples_path)
+        pl.scan_parquet(epiautogp_interop_paths.samples_path)
         .select(pl.col("date").min())
         .collect()
         .schema
@@ -127,7 +225,7 @@ def test_epiautogp_samples_parquet_date_is_discovered_by_polars(
 
 
 def test_epiautogp_samples_parquet_date_is_discovered_by_r_dplyr(
-    epiautogp_samples_path,
+    epiautogp_interop_paths,
 ):
     _skip_if_r_packages_missing("forecasttools", "dplyr", "lubridate")
     expected_dates_r = ", ".join(
@@ -136,8 +234,9 @@ def test_epiautogp_samples_parquet_date_is_discovered_by_r_dplyr(
     )
     r_code = textwrap.dedent(
         f"""
-        samples <- forecasttools::read_tabular({_quote_for_embedded_code(epiautogp_samples_path)})
+        samples <- forecasttools::read_tabular({_quote_for_embedded_code(epiautogp_interop_paths.samples_path)})
         stopifnot(inherits(samples$date, "Date"))
+        stopifnot(is.integer(samples[[".draw"]]))
         stopifnot(identical(
           as.character(samples$date),
           c({expected_dates_r})
@@ -158,3 +257,40 @@ def test_epiautogp_samples_parquet_date_is_discovered_by_r_dplyr(
         run_r_code(r_code, executor_flags=["--vanilla"], text=True)
     except FileNotFoundError:
         pytest.skip("Rscript is not available")
+
+
+def test_epiautogp_hubverse_table_combines_with_fable_and_pyrenew_outputs(
+    epiautogp_interop_paths,
+):
+    _skip_if_r_packages_missing(
+        "argparser",
+        "dplyr",
+        "forecasttools",
+        "fs",
+        "hewr",
+        "tidybayes",
+    )
+    try:
+        model_fit_dirs = [
+            epiautogp_interop_paths.model_fit_dir,
+            _write_fable_reference_model_samples(epiautogp_interop_paths.batch_dir),
+            _write_pyrenew_reference_model_samples(epiautogp_interop_paths.batch_dir),
+        ]
+        for model_fit_dir in model_fit_dirs:
+            model_fit_dir_to_hub_tbl(model_fit_dir)
+            hubverse_table_path = model_fit_dir / "hubverse_table.parquet"
+            assert hubverse_table_path.is_file()
+            hubverse_table = pl.read_parquet(hubverse_table_path)
+            # Sample .draw values become hubverse output_type_id values.
+            assert hubverse_table.schema["output_type_id"] == pl.Int32
+
+        combine_hubverse_tables(epiautogp_interop_paths.batch_dir)
+    except FileNotFoundError:
+        pytest.skip("Rscript is not available")
+
+    combined_path = (
+        epiautogp_interop_paths.batch_dir / "2024-02-03-covid-19-hubverse-table.parquet"
+    )
+    assert combined_path.is_file()
+    combined = pl.read_parquet(combined_path)
+    assert combined.schema["output_type_id"] == pl.Int32

--- a/pipelines/utils/postprocess_forecast_batches.py
+++ b/pipelines/utils/postprocess_forecast_batches.py
@@ -25,6 +25,8 @@ def _hubverse_table_filename(report_date: str | dt.date, disease: str) -> str:
     return f"{report_date}-{disease.lower()}-hubverse-table.parquet"
 
 
+# Batch collation assumes producer schemas already match. Type drift such as an
+# output_type_id integer/float mismatch should be fixed in the model output.
 def combine_hubverse_tables(model_batch_dir_path: str | Path) -> None:
     model_batch_dir_path = Path(model_batch_dir_path)
     model_batch_dir_name = model_batch_dir_path.name


### PR DESCRIPTION
This PR addresses the post-processing failure found in #1062 to close.

The problem was cross-model output schema drift where `EpiAutoGP` `output_type_id` was f64 and the eventual combine step was expecting i32. 

```python
cast_options=pl.ScanCastOptions(integer_cast="allow-float")
```

would allow this (I think) for one set of schema but the mismatch causes the error. 

The fix was to coerce `EpiAutoGP` into outputting to the common type rather than doing normalisation later on (I don't want to fiddle with the prod code).

I also beefed up the unit test that would have caught this by generating fixture output from each model and running the combination post-processing function on them so this should catch schema drift in the future.
