### PR TITLE
Issue 1057: Nowcast abstraction and use in NSSP nowcasting for `epiautogp`

### DIFF
--- a/pipelines/epiautogp/README.md
+++ b/pipelines/epiautogp/README.md
@@ -16,9 +16,10 @@ The forecasting pipeline consists of five main steps:
 
 1. **Setup**: Load data, validate dates, create directory structure
 2. **Data Preparation**: Process location data, evaluation data, and generate epiweekly datasets
-3. **Data Conversion**: Transform data into EpiAutoGP's JSON input format
-4. **Model Execution**: Run the Julia-based EpiAutoGP model
-5. **Post-processing**: Process outputs, create hubverse tables, and generate plots
+3. **Data nowcasting**: Either simple right-truncation correction or no nowcasting (further methods coming)
+4. **Data Conversion**: Transform data into EpiAutoGP's JSON input format
+5. **Model Execution**: Run the Julia-based EpiAutoGP model
+6. **Post-processing**: Process outputs, create hubverse tables, and generate plots
 
 ## Module Components
 
@@ -39,13 +40,29 @@ Main entry point for the forecasting pipeline.
 - `--n-forecast-draws`: Number of forecast draws (default: 2000)
 - `--smc-data-proportion`: Data proportion per SMC step (default: 0.1)
 
+### `forecast_spec.py`
+
+Defines the `ForecastSpec` value object — a frozen dataclass bundling the six fields that identify a single forecast run: `disease`, `loc`, `report_date`, `target`, `frequency`, `ed_visit_type`. These fields travel together through the pipeline and have inter-field validity constraints (see `_validate_epiautogp_parameters`), so they're treated as one cohesive unit. Lives in its own module to avoid an import cycle between `nowcast.py` and `epiautogp_forecast_utils.py`.
+
 ### `epiautogp_forecast_utils.py`
 
 Shared utilities for the forecast pipeline, containing modular functions for each pipeline stage.
 
 **Data Classes:**
-- **`ForecastPipelineContext`**: Container for shared pipeline state (disease, location, dates, data sources, logger)
+- **`ForecastPipelineContext`**: Container for shared pipeline state. Embeds a `ForecastSpec` plus workflow-only fields (training dates, output directories, data sources, logger, nowcast source).
 - **`ModelPaths`**: Container for output directory structure and file paths
+
+**Key Functions:**
+- **`setup_forecast_pipeline()`**: Builds the `ForecastSpec`, resolves the nowcast source, and assembles a `ForecastPipelineContext` for downstream stages.
+- **`_resolve_nowcast_source()`**: Dispatches on `nowcast_source_name` to construct a `NowcastSource`. Universal args (`forecast_spec`, `nowcast_source_name`) are explicit; source-specific options are forwarded via `**kwargs` to the chosen builder, which validates them.
+
+### `nowcast.py` & `reporting_delay_nowcast.py`
+
+Pluggable nowcasting sources for nowcasting recent observations.
+
+- **`NowcastSource`** (Protocol): Declares `applies_to(*, forecast_spec) -> bool` (the predicate the resolver queries before constructing) and `get_nowcast_data(*, dates, reports) -> NowcastData` (the action).
+- **`FixedNowcast`**: Trivial source wrapping a precomputed `NowcastData`.
+- **`ReportingDelayNowcast`**: Inflates the most-recent observations by the inverse of a reporting-delay PMF. Applies to count series (rejects `ed_visit_type="pct"`); warns when used on a non-daily series since the PMF support is daily by convention.
 
 ### `prep_epiautogp_data.py`
 
@@ -73,6 +90,8 @@ Data conversion utilities for EpiAutoGP JSON format.
   "pathogen": "COVID-19",
   "location": "DC",
   "target": "nssp",
+  "frequency": "daily",
+  "ed_visit_type": "observed",
   "forecast_date": "2024-12-20",
   "nowcast_dates": [],
   "nowcast_reports": []

--- a/pipelines/epiautogp/__init__.py
+++ b/pipelines/epiautogp/__init__.py
@@ -3,12 +3,19 @@ EpiAutoGP integration module for cfa-stf-routine-forecasting pipelines.
 """
 
 from pipelines.epiautogp.epiautogp_forecast_utils import setup_forecast_pipeline
-from pipelines.epiautogp.nowcast import NowcastData, NowcastSource
+from pipelines.epiautogp.nowcast import FixedNowcast, NowcastData, NowcastSource
 from pipelines.epiautogp.prep_epiautogp_data import convert_to_epiautogp_json
+from pipelines.epiautogp.reporting_delay import (
+    inflate_report,
+    reporting_inflation_factors,
+)
 
 __all__ = [
     "convert_to_epiautogp_json",
+    "FixedNowcast",
+    "inflate_report",
     "NowcastData",
     "NowcastSource",
+    "reporting_inflation_factors",
     "setup_forecast_pipeline",
 ]

--- a/pipelines/epiautogp/__init__.py
+++ b/pipelines/epiautogp/__init__.py
@@ -3,9 +3,12 @@ EpiAutoGP integration module for cfa-stf-routine-forecasting pipelines.
 """
 
 from pipelines.epiautogp.epiautogp_forecast_utils import setup_forecast_pipeline
+from pipelines.epiautogp.nowcast import NowcastData, NowcastModel
 from pipelines.epiautogp.prep_epiautogp_data import convert_to_epiautogp_json
 
 __all__ = [
     "convert_to_epiautogp_json",
+    "NowcastData",
+    "NowcastModel",
     "setup_forecast_pipeline",
 ]

--- a/pipelines/epiautogp/__init__.py
+++ b/pipelines/epiautogp/__init__.py
@@ -3,12 +3,12 @@ EpiAutoGP integration module for cfa-stf-routine-forecasting pipelines.
 """
 
 from pipelines.epiautogp.epiautogp_forecast_utils import setup_forecast_pipeline
-from pipelines.epiautogp.nowcast import NowcastData, NowcastModel
+from pipelines.epiautogp.nowcast import NowcastData, NowcastSource
 from pipelines.epiautogp.prep_epiautogp_data import convert_to_epiautogp_json
 
 __all__ = [
     "convert_to_epiautogp_json",
     "NowcastData",
-    "NowcastModel",
+    "NowcastSource",
     "setup_forecast_pipeline",
 ]

--- a/pipelines/epiautogp/epiautogp_forecast_utils.py
+++ b/pipelines/epiautogp/epiautogp_forecast_utils.py
@@ -15,8 +15,8 @@ from typing import Any, Literal
 import polars as pl
 
 from pipelines.data.prep_data import get_pmfs, process_and_save_loc_data
-from pipelines.epiautogp.nssp_nowcast import NsspRightTruncationNowcast
 from pipelines.epiautogp.nowcast import NowcastSource
+from pipelines.epiautogp.nssp_nowcast import NsspRightTruncationNowcast
 from pipelines.utils.common_utils import (
     append_prop_data_to_combined_data,
     calculate_training_dates,
@@ -157,6 +157,7 @@ class ForecastPipelineContext:
         model_fit_dir_to_hub_tbl(model_fit_dir)
         self.logger.info("Postprocessing complete.")
 
+
 def _use_right_truncation_nowcasting_auto(
     *,
     target: str,
@@ -182,6 +183,7 @@ def _use_right_truncation_nowcasting_auto(
         True if right-truncation nowcasting should be used, False otherwise
     """
     return target == "nssp" and ed_visit_type in ["observed", "other"]
+
 
 def _use_right_truncation_nowcasting_right_truncation(
     *,
@@ -209,15 +211,14 @@ def _use_right_truncation_nowcasting_right_truncation(
     """
     if target != "nssp":
         raise ValueError(
-            "right-truncation nowcasting is currently supported only "
-            "for target='nssp'."
+            "right-truncation nowcasting is currently supported only for target='nssp'."
         )
     if ed_visit_type == "pct":
         raise ValueError(
-            "right-truncation nowcasting is not supported for "
-            "ed_visit_type='pct'."
+            "right-truncation nowcasting is not supported for ed_visit_type='pct'."
         )
     return True
+
 
 def _generate_right_truncation_nowcast(
     *,
@@ -229,8 +230,7 @@ def _generate_right_truncation_nowcast(
     param_data_dir: Path | str | None,
     logger: logging.Logger,
 ) -> NsspRightTruncationNowcast:
-    """Generate a right-truncation nowcast source for EpiAutoGP.
-    """ 
+    """Generate a right-truncation nowcast source for EpiAutoGP."""
     if frequency != "daily":
         logger.warning(
             "Using right-truncation nowcasting for frequency=%r. Confirm that "
@@ -254,6 +254,7 @@ def _generate_right_truncation_nowcast(
         )["right_truncation_pmf"]
 
     return NsspRightTruncationNowcast(right_truncation_pmf=right_truncation_pmf)
+
 
 def _resolve_nowcast_source(
     *,

--- a/pipelines/epiautogp/epiautogp_forecast_utils.py
+++ b/pipelines/epiautogp/epiautogp_forecast_utils.py
@@ -10,13 +10,13 @@ import os
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
 import polars as pl
 
 from pipelines.data.prep_data import get_pmfs, process_and_save_loc_data
 from pipelines.epiautogp.nowcast import NowcastSource
-from pipelines.epiautogp.nssp_nowcast import NsspRightTruncationNowcast
+from pipelines.epiautogp.reporting_delay_nowcast import ReportingDelayNowcast
 from pipelines.utils.common_utils import (
     append_prop_data_to_combined_data,
     calculate_training_dates,
@@ -28,7 +28,8 @@ from pipelines.utils.common_utils import (
     model_fit_dir_to_hub_tbl,
 )
 
-NowcastSourceName = Literal["auto", "none", "right-truncation"]
+NowcastSourceName = Literal["none", "reporting-delay"]
+VALID_NOWCAST_SOURCE_NAMES: tuple[str, ...] = get_args(NowcastSourceName)
 
 
 @dataclass
@@ -158,102 +159,30 @@ class ForecastPipelineContext:
         self.logger.info("Postprocessing complete.")
 
 
-def _use_right_truncation_nowcasting_auto(
+def _build_reporting_delay_nowcast(
     *,
-    target: str,
-    ed_visit_type: str,
-) -> bool:
-    """
-    Determine whether right-truncation nowcasting should be used based on the
-    target and ED visit type when nowcast_source_name="auto".
-
-    Right-truncation nowcasting is currently only supported for NSSP targets with
-    "observed" or "other" ED visit types.
-
-    Parameters
-    ----------
-    target : str
-        Target data type (e.g., "nssp", "nhsn")
-    ed_visit_type : str
-        Type of ED visits (e.g., "observed", "other", "pct")
-
-    Returns
-    -------
-    bool
-        True if right-truncation nowcasting should be used, False otherwise
-    """
-    return target == "nssp" and ed_visit_type in ["observed", "other"]
-
-
-def _use_right_truncation_nowcasting_right_truncation(
-    *,
-    target: str,
-    ed_visit_type: str,
-) -> bool:
-    """
-    Determine whether right-truncation nowcasting should be used based on the
-    target and ED visit type when nowcast_source_name="right-truncation".
-
-    Right-truncation nowcasting is currently only supported for NSSP targets with
-    "observed" or "other" ED visit types.
-
-    Parameters
-    ----------
-    target : str
-        Target data type (e.g., "nssp", "nhsn")
-    ed_visit_type : str
-        Type of ED visits (e.g., "observed", "other", "pct")
-
-    Returns
-    -------
-    bool
-        True if right-truncation nowcasting should be used, False otherwise
-    """
-    if target != "nssp":
-        raise ValueError(
-            "right-truncation nowcasting is currently supported only for target='nssp'."
-        )
-    if ed_visit_type == "pct":
-        raise ValueError(
-            "right-truncation nowcasting is not supported for ed_visit_type='pct'."
-        )
-    return True
-
-
-def _generate_right_truncation_nowcast(
-    *,
-    right_truncation_pmf: list[float] | None,
+    reporting_delay_pmf: list[float] | None,
     disease: str,
     loc: str,
-    frequency: str,
     report_date: date,
     param_data_dir: Path | str | None,
-    logger: logging.Logger,
-) -> NsspRightTruncationNowcast:
-    """Generate a right-truncation nowcast source for EpiAutoGP."""
-    if frequency != "daily":
-        logger.warning(
-            "Using right-truncation nowcasting for frequency=%r. Confirm that "
-            "the right-truncation PMF is indexed to the cadence of the model "
-            "series being nowcast.",
-            frequency,
-        )
-
-    if right_truncation_pmf is None:
+) -> ReportingDelayNowcast:
+    """Build a ReportingDelayNowcast, fetching the PMF if not supplied."""
+    if reporting_delay_pmf is None:
         if param_data_dir is None:
             raise ValueError(
-                "param_data_dir is required when right-truncation nowcasting "
-                "is requested without a directly supplied right_truncation_pmf."
+                "param_data_dir is required when reporting-delay nowcasting "
+                "is requested without a directly supplied reporting_delay_pmf."
             )
         param_estimates = pl.scan_parquet(Path(param_data_dir, "prod.parquet"))
-        right_truncation_pmf = get_pmfs(
+        reporting_delay_pmf = get_pmfs(
             param_estimates=param_estimates,
             loc_abb=loc,
             disease=disease,
             as_of=report_date,
         )["right_truncation_pmf"]
 
-    return NsspRightTruncationNowcast(right_truncation_pmf=right_truncation_pmf)
+    return ReportingDelayNowcast(reporting_delay_pmf=reporting_delay_pmf)
 
 
 def _resolve_nowcast_source(
@@ -266,46 +195,49 @@ def _resolve_nowcast_source(
     report_date: date,
     param_data_dir: Path | str | None,
     nowcast_source_name: NowcastSourceName,
-    right_truncation_pmf: list[float] | None,
+    reporting_delay_pmf: list[float] | None,
     logger: logging.Logger,
 ) -> NowcastSource | None:
     """
     Resolve the requested nowcast source for one EpiAutoGP run.
+
+    The keyword maps directly to a nowcast approach; each source's `applies_to`
+    method decides whether the requested configuration is supported.
+    Reporting-delay also logs a soft cadence warning for non-daily runs
+    because the PMF support is daily by convention.
     """
-    valid_sources = ["auto", "none", "right-truncation"]
-    if nowcast_source_name not in valid_sources:
+    if nowcast_source_name not in VALID_NOWCAST_SOURCE_NAMES:
         raise ValueError(
-            f"nowcast_source_name must be one of {valid_sources}, "
+            f"nowcast_source_name must be one of {list(VALID_NOWCAST_SOURCE_NAMES)}, "
             f"got {nowcast_source_name!r}"
         )
 
     if nowcast_source_name == "none":
         return None
 
-    use_right_truncation = False
-    if nowcast_source_name == "auto":
-        use_right_truncation = _use_right_truncation_nowcasting_auto(
-            target=target,
-            ed_visit_type=ed_visit_type,
-        )
-    elif nowcast_source_name == "right-truncation":
-        use_right_truncation = _use_right_truncation_nowcasting_right_truncation(
-            target=target,
-            ed_visit_type=ed_visit_type,
-        )
-
-    if use_right_truncation:
-        return _generate_right_truncation_nowcast(
-            right_truncation_pmf=right_truncation_pmf,
+    if nowcast_source_name == "reporting-delay":
+        if not ReportingDelayNowcast.applies_to(
+            target=target, ed_visit_type=ed_visit_type, frequency=frequency
+        ):
+            raise ValueError(
+                f"reporting-delay nowcasting is not applicable to "
+                f"target={target!r}, ed_visit_type={ed_visit_type!r}."
+            )
+        if frequency != "daily":
+            logger.warning(
+                "Using reporting-delay nowcasting for frequency=%r. Confirm "
+                "the reporting-delay PMF support matches the model cadence.",
+                frequency,
+            )
+        return _build_reporting_delay_nowcast(
+            reporting_delay_pmf=reporting_delay_pmf,
             disease=disease,
             loc=loc,
-            frequency=frequency,
             report_date=report_date,
             param_data_dir=param_data_dir,
-            logger=logger,
         )
-    else:
-        return None
+
+    raise ValueError(f"unhandled nowcast_source_name: {nowcast_source_name!r}")
 
 
 def setup_forecast_pipeline(
@@ -325,8 +257,8 @@ def setup_forecast_pipeline(
     credentials_path: Path | None = None,
     logger: logging.Logger | None = None,
     param_data_dir: Path | str | None = None,
-    nowcast_source_name: NowcastSourceName = "auto",
-    right_truncation_pmf: list[float] | None = None,
+    nowcast_source_name: NowcastSourceName = "none",
+    reporting_delay_pmf: list[float] | None = None,
 ) -> ForecastPipelineContext:
     """
     Set up common forecast pipeline infrastructure.
@@ -375,14 +307,14 @@ def setup_forecast_pipeline(
     logger : logging.Logger | None, default=None
         Logger instance. If None, creates a new logger
     param_data_dir : Path | str | None, default=None
-        Directory containing parameter estimates such as right-truncation PMFs.
-        Required when right-truncation nowcasting is selected and no PMF is
+        Directory containing parameter estimates such as reporting-delay PMFs.
+        Required when reporting-delay nowcasting is selected and no PMF is
         directly supplied.
-    nowcast_source_name : {"auto", "none", "right-truncation"}, default="auto"
+    nowcast_source_name : {"none", "reporting-delay"}, default="none"
         Nowcast source selection for EpiAutoGP input.
-    right_truncation_pmf : list[float] | None, default=None
-        Directly supplied right-truncation PMF. Takes precedence over
-        param_data_dir when right-truncation nowcasting is selected.
+    reporting_delay_pmf : list[float] | None, default=None
+        Directly supplied reporting-delay PMF. Takes precedence over
+        param_data_dir when reporting-delay nowcasting is selected.
 
     Returns
     -------
@@ -444,7 +376,7 @@ def setup_forecast_pipeline(
         report_date=report_date_parsed,
         param_data_dir=param_data_dir,
         nowcast_source_name=nowcast_source_name,
-        right_truncation_pmf=right_truncation_pmf,
+        reporting_delay_pmf=reporting_delay_pmf,
         logger=logger,
     )
 

--- a/pipelines/epiautogp/epiautogp_forecast_utils.py
+++ b/pipelines/epiautogp/epiautogp_forecast_utils.py
@@ -206,38 +206,29 @@ def _resolve_nowcast_source(
     Reporting-delay also logs a soft cadence warning for non-daily runs
     because the PMF support is daily by convention.
     """
-    if nowcast_source_name not in VALID_NOWCAST_SOURCE_NAMES:
-        raise ValueError(
-            f"nowcast_source_name must be one of {list(VALID_NOWCAST_SOURCE_NAMES)}, "
-            f"got {nowcast_source_name!r}"
-        )
-
-    if nowcast_source_name == "none":
-        return None
-
-    if nowcast_source_name == "reporting-delay":
-        if not ReportingDelayNowcast.applies_to(
-            target=target, ed_visit_type=ed_visit_type, frequency=frequency
-        ):
+    match nowcast_source_name:
+        case "none":
+            return None
+        case "reporting-delay":
+            if not ReportingDelayNowcast.applies_to(
+                target=target, ed_visit_type=ed_visit_type, frequency=frequency
+            ):
+                raise ValueError(
+                    f"reporting-delay nowcasting is not applicable to "
+                    f"target={target!r}, ed_visit_type={ed_visit_type!r}."
+                )
+            return _build_reporting_delay_nowcast(
+                reporting_delay_pmf=reporting_delay_pmf,
+                disease=disease,
+                loc=loc,
+                report_date=report_date,
+                param_data_dir=param_data_dir,
+            )
+        case _:
             raise ValueError(
-                f"reporting-delay nowcasting is not applicable to "
-                f"target={target!r}, ed_visit_type={ed_visit_type!r}."
+                f"nowcast_source_name must be one of {list(VALID_NOWCAST_SOURCE_NAMES)}, "
+                f"got {nowcast_source_name!r}"
             )
-        if frequency != "daily":
-            logger.warning(
-                "Using reporting-delay nowcasting for frequency=%r. Confirm "
-                "the reporting-delay PMF support matches the model cadence.",
-                frequency,
-            )
-        return _build_reporting_delay_nowcast(
-            reporting_delay_pmf=reporting_delay_pmf,
-            disease=disease,
-            loc=loc,
-            report_date=report_date,
-            param_data_dir=param_data_dir,
-        )
-
-    raise ValueError(f"unhandled nowcast_source_name: {nowcast_source_name!r}")
 
 
 def setup_forecast_pipeline(

--- a/pipelines/epiautogp/epiautogp_forecast_utils.py
+++ b/pipelines/epiautogp/epiautogp_forecast_utils.py
@@ -15,6 +15,7 @@ from typing import Any, Literal, get_args
 import polars as pl
 
 from pipelines.data.prep_data import get_pmfs, process_and_save_loc_data
+from pipelines.epiautogp.forecast_spec import ForecastSpec
 from pipelines.epiautogp.nowcast import NowcastSource
 from pipelines.epiautogp.reporting_delay_nowcast import ReportingDelayNowcast
 from pipelines.utils.common_utils import (
@@ -57,14 +58,9 @@ class ForecastPipelineContext:
     to be passed between functions.
     """
 
-    disease: str
-    loc: str
-    target: str
-    frequency: str
-    ed_visit_type: str
+    forecast_spec: ForecastSpec
     model_name: str
     nhsn_data_path: Path | None
-    report_date: date
     first_training_date: date
     last_training_date: date
     n_forecast_days: int
@@ -97,14 +93,14 @@ class ForecastPipelineContext:
         data_dir = Path(model_output_dir, "data")
         os.makedirs(data_dir, exist_ok=True)
 
-        self.logger.info(f"Processing data for {self.loc}")
+        self.logger.info(f"Processing data for {self.forecast_spec.loc}")
 
         # Process and save location data
         process_and_save_loc_data(
-            loc_abb=self.loc,
-            disease=self.disease,
+            loc_abb=self.forecast_spec.loc,
+            disease=self.forecast_spec.disease,
             facility_level_nssp_data=self.facility_level_nssp_data,
-            report_date=self.report_date,
+            report_date=self.forecast_spec.report_date,
             first_training_date=self.first_training_date,
             last_training_date=self.last_training_date,
             save_dir=data_dir,
@@ -115,7 +111,7 @@ class ForecastPipelineContext:
 
         # Generate epiweekly datasets
         # only do this if we're fitting an epiweekly model
-        if self.frequency == "epiweekly":
+        if self.forecast_spec.frequency == "epiweekly":
             self.logger.info("Generating epiweekly datasets from daily datasets...")
             generate_epiweekly_data(data_dir, overwrite_daily=True)
 
@@ -161,10 +157,8 @@ class ForecastPipelineContext:
 
 def _build_reporting_delay_nowcast(
     *,
+    forecast_spec: ForecastSpec,
     reporting_delay_pmf: list[float] | None,
-    disease: str,
-    loc: str,
-    report_date: date,
     param_data_dir: Path | str | None,
 ) -> ReportingDelayNowcast:
     """Build a ReportingDelayNowcast, fetching the PMF if not supplied."""
@@ -177,9 +171,9 @@ def _build_reporting_delay_nowcast(
         param_estimates = pl.scan_parquet(Path(param_data_dir, "prod.parquet"))
         reporting_delay_pmf = get_pmfs(
             param_estimates=param_estimates,
-            loc_abb=loc,
-            disease=disease,
-            as_of=report_date,
+            loc_abb=forecast_spec.loc,
+            disease=forecast_spec.disease,
+            as_of=forecast_spec.report_date,
         )["right_truncation_pmf"]
 
     return ReportingDelayNowcast(reporting_delay_pmf=reporting_delay_pmf)
@@ -187,42 +181,29 @@ def _build_reporting_delay_nowcast(
 
 def _resolve_nowcast_source(
     *,
-    disease: str,
-    loc: str,
-    target: str,
-    frequency: str,
-    ed_visit_type: str,
-    report_date: date,
-    param_data_dir: Path | str | None,
+    forecast_spec: ForecastSpec,
     nowcast_source_name: NowcastSourceName,
-    reporting_delay_pmf: list[float] | None,
-    logger: logging.Logger,
+    **options: Any,
 ) -> NowcastSource | None:
     """
     Resolve the requested nowcast source for one EpiAutoGP run.
 
-    The keyword maps directly to a nowcast approach; each source's `applies_to`
-    method decides whether the requested configuration is supported.
-    Reporting-delay also logs a soft cadence warning for non-daily runs
-    because the PMF support is daily by convention.
+    `forecast_spec` and `nowcast_source_name` are universal; remaining keyword
+    arguments are forwarded as-is to the chosen source's builder, which is
+    responsible for validating them. New nowcast approaches plug in by adding
+    a new case here and a builder that defines its own required kwargs.
     """
     match nowcast_source_name:
         case "none":
             return None
         case "reporting-delay":
-            if not ReportingDelayNowcast.applies_to(
-                target=target, ed_visit_type=ed_visit_type, frequency=frequency
-            ):
+            if not ReportingDelayNowcast.applies_to(forecast_spec=forecast_spec):
                 raise ValueError(
                     f"reporting-delay nowcasting is not applicable to "
-                    f"target={target!r}, ed_visit_type={ed_visit_type!r}."
+                    f"target={forecast_spec.target!r}, ed_visit_type={forecast_spec.ed_visit_type!r}."
                 )
             return _build_reporting_delay_nowcast(
-                reporting_delay_pmf=reporting_delay_pmf,
-                disease=disease,
-                loc=loc,
-                report_date=report_date,
-                param_data_dir=param_data_dir,
+                forecast_spec=forecast_spec, **options
             )
         case _:
             raise ValueError(
@@ -330,6 +311,16 @@ def setup_forecast_pipeline(
 
     report_date_parsed = max(available_facility_level_reports)
 
+    # Gather the forecast specification input parameters into a single cohesive unit
+    forecast_spec = ForecastSpec(
+        disease=disease,
+        loc=loc,
+        report_date=report_date_parsed,
+        target=target,
+        frequency=frequency,
+        ed_visit_type=ed_visit_type,
+    )
+
     # Calculate training dates
     first_training_date, last_training_date = calculate_training_dates(
         report_date_parsed,
@@ -359,27 +350,16 @@ def setup_forecast_pipeline(
 
     # Resolve nowcast source
     resolved_nowcast_source = _resolve_nowcast_source(
-        disease=disease,
-        loc=loc,
-        target=target,
-        frequency=frequency,
-        ed_visit_type=ed_visit_type,
-        report_date=report_date_parsed,
-        param_data_dir=param_data_dir,
+        forecast_spec=forecast_spec,
         nowcast_source_name=nowcast_source_name,
+        param_data_dir=param_data_dir,
         reporting_delay_pmf=reporting_delay_pmf,
-        logger=logger,
     )
 
     return ForecastPipelineContext(
-        disease=disease,
-        loc=loc,
-        target=target,
-        frequency=frequency,
-        ed_visit_type=ed_visit_type,
+        forecast_spec=forecast_spec,
         model_name=model_name,
         nhsn_data_path=nhsn_data_path,
-        report_date=report_date_parsed,
         first_training_date=first_training_date,
         last_training_date=last_training_date,
         n_forecast_days=n_forecast_days,

--- a/pipelines/epiautogp/epiautogp_forecast_utils.py
+++ b/pipelines/epiautogp/epiautogp_forecast_utils.py
@@ -10,11 +10,13 @@ import os
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import polars as pl
 
-from pipelines.data.prep_data import process_and_save_loc_data
+from pipelines.data.prep_data import get_pmfs, process_and_save_loc_data
+from pipelines.epiautogp.nssp_nowcast import NsspRightTruncationNowcast
+from pipelines.epiautogp.nowcast import NowcastSource
 from pipelines.utils.common_utils import (
     append_prop_data_to_combined_data,
     calculate_training_dates,
@@ -25,6 +27,8 @@ from pipelines.utils.common_utils import (
     make_figures_from_model_fit_dir,
     model_fit_dir_to_hub_tbl,
 )
+
+NowcastSourceName = Literal["auto", "none", "right-truncation"]
 
 
 @dataclass
@@ -70,6 +74,7 @@ class ForecastPipelineContext:
     credentials_dict: dict[str, Any]
     facility_level_nssp_data: pl.LazyFrame
     logger: logging.Logger
+    nowcast_source: NowcastSource | None = None
 
     def prepare_model_data(self) -> ModelPaths:
         """
@@ -152,6 +157,155 @@ class ForecastPipelineContext:
         model_fit_dir_to_hub_tbl(model_fit_dir)
         self.logger.info("Postprocessing complete.")
 
+def _use_right_truncation_nowcasting_auto(
+    *,
+    target: str,
+    ed_visit_type: str,
+) -> bool:
+    """
+    Determine whether right-truncation nowcasting should be used based on the
+    target and ED visit type when nowcast_source_name="auto".
+
+    Right-truncation nowcasting is currently only supported for NSSP targets with
+    "observed" or "other" ED visit types.
+
+    Parameters
+    ----------
+    target : str
+        Target data type (e.g., "nssp", "nhsn")
+    ed_visit_type : str
+        Type of ED visits (e.g., "observed", "other", "pct")
+
+    Returns
+    -------
+    bool
+        True if right-truncation nowcasting should be used, False otherwise
+    """
+    return target == "nssp" and ed_visit_type in ["observed", "other"]
+
+def _use_right_truncation_nowcasting_right_truncation(
+    *,
+    target: str,
+    ed_visit_type: str,
+) -> bool:
+    """
+    Determine whether right-truncation nowcasting should be used based on the
+    target and ED visit type when nowcast_source_name="right-truncation".
+
+    Right-truncation nowcasting is currently only supported for NSSP targets with
+    "observed" or "other" ED visit types.
+
+    Parameters
+    ----------
+    target : str
+        Target data type (e.g., "nssp", "nhsn")
+    ed_visit_type : str
+        Type of ED visits (e.g., "observed", "other", "pct")
+
+    Returns
+    -------
+    bool
+        True if right-truncation nowcasting should be used, False otherwise
+    """
+    if target != "nssp":
+        raise ValueError(
+            "right-truncation nowcasting is currently supported only "
+            "for target='nssp'."
+        )
+    if ed_visit_type == "pct":
+        raise ValueError(
+            "right-truncation nowcasting is not supported for "
+            "ed_visit_type='pct'."
+        )
+    return True
+
+def _generate_right_truncation_nowcast(
+    *,
+    right_truncation_pmf: list[float] | None,
+    disease: str,
+    loc: str,
+    frequency: str,
+    report_date: date,
+    param_data_dir: Path | str | None,
+    logger: logging.Logger,
+) -> NsspRightTruncationNowcast:
+    """Generate a right-truncation nowcast source for EpiAutoGP.
+    """ 
+    if frequency != "daily":
+        logger.warning(
+            "Using right-truncation nowcasting for frequency=%r. Confirm that "
+            "the right-truncation PMF is indexed to the cadence of the model "
+            "series being nowcast.",
+            frequency,
+        )
+
+    if right_truncation_pmf is None:
+        if param_data_dir is None:
+            raise ValueError(
+                "param_data_dir is required when right-truncation nowcasting "
+                "is requested without a directly supplied right_truncation_pmf."
+            )
+        param_estimates = pl.scan_parquet(Path(param_data_dir, "prod.parquet"))
+        right_truncation_pmf = get_pmfs(
+            param_estimates=param_estimates,
+            loc_abb=loc,
+            disease=disease,
+            as_of=report_date,
+        )["right_truncation_pmf"]
+
+    return NsspRightTruncationNowcast(right_truncation_pmf=right_truncation_pmf)
+
+def _resolve_nowcast_source(
+    *,
+    disease: str,
+    loc: str,
+    target: str,
+    frequency: str,
+    ed_visit_type: str,
+    report_date: date,
+    param_data_dir: Path | str | None,
+    nowcast_source_name: NowcastSourceName,
+    right_truncation_pmf: list[float] | None,
+    logger: logging.Logger,
+) -> NowcastSource | None:
+    """
+    Resolve the requested nowcast source for one EpiAutoGP run.
+    """
+    valid_sources = ["auto", "none", "right-truncation"]
+    if nowcast_source_name not in valid_sources:
+        raise ValueError(
+            f"nowcast_source_name must be one of {valid_sources}, "
+            f"got {nowcast_source_name!r}"
+        )
+
+    if nowcast_source_name == "none":
+        return None
+
+    use_right_truncation = False
+    if nowcast_source_name == "auto":
+        use_right_truncation = _use_right_truncation_nowcasting_auto(
+            target=target,
+            ed_visit_type=ed_visit_type,
+        )
+    elif nowcast_source_name == "right-truncation":
+        use_right_truncation = _use_right_truncation_nowcasting_right_truncation(
+            target=target,
+            ed_visit_type=ed_visit_type,
+        )
+
+    if use_right_truncation:
+        return _generate_right_truncation_nowcast(
+            right_truncation_pmf=right_truncation_pmf,
+            disease=disease,
+            loc=loc,
+            frequency=frequency,
+            report_date=report_date,
+            param_data_dir=param_data_dir,
+            logger=logger,
+        )
+    else:
+        return None
+
 
 def setup_forecast_pipeline(
     disease: str,
@@ -169,6 +323,9 @@ def setup_forecast_pipeline(
     exclude_date_ranges: list[tuple[date, date]] | None = None,
     credentials_path: Path | None = None,
     logger: logging.Logger | None = None,
+    param_data_dir: Path | str | None = None,
+    nowcast_source_name: NowcastSourceName = "auto",
+    right_truncation_pmf: list[float] | None = None,
 ) -> ForecastPipelineContext:
     """
     Set up common forecast pipeline infrastructure.
@@ -181,6 +338,7 @@ def setup_forecast_pipeline(
     4. Calculate training dates
     5. Load NSSP data
     6. Create batch directory structure
+    7. Resolve nowcasting source based on input parameters and available data
 
     Parameters
     ----------
@@ -215,6 +373,15 @@ def setup_forecast_pipeline(
         Path to credentials file
     logger : logging.Logger | None, default=None
         Logger instance. If None, creates a new logger
+    param_data_dir : Path | str | None, default=None
+        Directory containing parameter estimates such as right-truncation PMFs.
+        Required when right-truncation nowcasting is selected and no PMF is
+        directly supplied.
+    nowcast_source_name : {"auto", "none", "right-truncation"}, default="auto"
+        Nowcast source selection for EpiAutoGP input.
+    right_truncation_pmf : list[float] | None, default=None
+        Directly supplied right-truncation PMF. Takes precedence over
+        param_data_dir when right-truncation nowcasting is selected.
 
     Returns
     -------
@@ -266,6 +433,20 @@ def setup_forecast_pipeline(
     logger.info(f"Model batch directory: {model_batch_dir}")
     logger.info(f"Model run directory: {model_run_dir}")
 
+    # Resolve nowcast source
+    resolved_nowcast_source = _resolve_nowcast_source(
+        disease=disease,
+        loc=loc,
+        target=target,
+        frequency=frequency,
+        ed_visit_type=ed_visit_type,
+        report_date=report_date_parsed,
+        param_data_dir=param_data_dir,
+        nowcast_source_name=nowcast_source_name,
+        right_truncation_pmf=right_truncation_pmf,
+        logger=logger,
+    )
+
     return ForecastPipelineContext(
         disease=disease,
         loc=loc,
@@ -285,4 +466,5 @@ def setup_forecast_pipeline(
         credentials_dict=credentials_dict,
         facility_level_nssp_data=facility_level_nssp_data,
         logger=logger,
+        nowcast_source=resolved_nowcast_source,
     )

--- a/pipelines/epiautogp/forecast_epiautogp.py
+++ b/pipelines/epiautogp/forecast_epiautogp.py
@@ -6,6 +6,9 @@ from pipelines.epiautogp import (
     convert_to_epiautogp_json,
     setup_forecast_pipeline,
 )
+from pipelines.epiautogp.epiautogp_forecast_utils import (
+    VALID_NOWCAST_SOURCE_NAMES,
+)
 from pipelines.utils.cli_utils import add_common_forecast_arguments
 from pipelines.utils.common_utils import (
     parse_exclude_date_ranges,
@@ -101,8 +104,8 @@ def main(
     smc_data_proportion: float = 0.1,
     n_threads: int | str = "auto",
     param_data_dir: Path | str = Path("private_data", "prod_param_estimates"),
-    nowcast_source_name: str = "auto",
-    right_truncation_pmf: list[float] | None = None,
+    nowcast_source_name: str = "none",
+    reporting_delay_pmf: list[float] | None = None,
 ) -> None:
     """
     Run the complete EpiAutoGP forecasting pipeline for a single location.
@@ -126,7 +129,7 @@ def main(
     facility_level_nssp_data_dir : Path | str
         Directory containing facility-level NSSP ED visit data
     param_data_dir : Path | str
-        Directory containing parameter estimates such as right-truncation PMFs
+        Directory containing parameter estimates such as reporting-delay PMFs
     output_dir : Path | str
         Root directory for output
     n_training_days : int
@@ -162,10 +165,10 @@ def main(
         Proportion of data used in each SMC step
     n_threads : int | str, default="auto"
         Number of threads for Julia execution (integer or "auto")
-    nowcast_source_name : str, default="auto"
-        Nowcast source to use: "auto", "none", or "right-truncation"
-    right_truncation_pmf : list[float] | None, default=None
-        Directly supplied right-truncation PMF. Python API only.
+    nowcast_source_name : str, default="none"
+        Nowcast source to use: "none" or "reporting-delay"
+    reporting_delay_pmf : list[float] | None, default=None
+        Directly supplied reporting-delay PMF. Python API only.
 
     Returns
     -------
@@ -260,7 +263,7 @@ def main(
         logger=logger,
         param_data_dir=param_data_dir,
         nowcast_source_name=nowcast_source_name,
-        right_truncation_pmf=right_truncation_pmf,
+        reporting_delay_pmf=reporting_delay_pmf,
     )
 
     # Step 2: Prepare data for modelling (process location data, epiweekly data)
@@ -348,19 +351,19 @@ if __name__ == "__main__":
         "--param-data-dir",
         type=Path,
         default=Path("private_data", "prod_param_estimates"),
-        help="Directory containing parameter estimates such as right-truncation PMFs.",
+        help="Directory containing parameter estimates such as reporting-delay PMFs.",
     )
 
     parser.add_argument(
         "--nowcast-source",
         dest="nowcast_source_name",
         type=str,
-        default="auto",
-        choices=["auto", "none", "right-truncation"],
+        default="none",
+        choices=list(VALID_NOWCAST_SOURCE_NAMES),
         help=(
-            "Nowcast source to use: 'auto' selects the default for the target, "
-            "'none' disables nowcasting, and 'right-truncation' forces "
-            "right-truncation nowcasting where supported (default: auto)."
+            "Nowcast source to use: 'none' disables nowcasting; "
+            "'reporting-delay' inflates recent counts using a reporting-delay "
+            "PMF (default: none)."
         ),
     )
 

--- a/pipelines/epiautogp/forecast_epiautogp.py
+++ b/pipelines/epiautogp/forecast_epiautogp.py
@@ -100,6 +100,9 @@ def main(
     n_forecast_draws: int = 2000,
     smc_data_proportion: float = 0.1,
     n_threads: int | str = "auto",
+    param_data_dir: Path | str = Path("private_data", "prod_param_estimates"),
+    nowcast_source_name: str = "auto",
+    right_truncation_pmf: list[float] | None = None,
 ) -> None:
     """
     Run the complete EpiAutoGP forecasting pipeline for a single location.
@@ -122,6 +125,8 @@ def main(
         Two-letter USPS location abbreviation (e.g., "CA", "NY")
     facility_level_nssp_data_dir : Path | str
         Directory containing facility-level NSSP ED visit data
+    param_data_dir : Path | str
+        Directory containing parameter estimates such as right-truncation PMFs
     output_dir : Path | str
         Root directory for output
     n_training_days : int
@@ -157,6 +162,10 @@ def main(
         Proportion of data used in each SMC step
     n_threads : int | str, default="auto"
         Number of threads for Julia execution (integer or "auto")
+    nowcast_source_name : str, default="auto"
+        Nowcast source to use: "auto", "none", or "right-truncation"
+    right_truncation_pmf : list[float] | None, default=None
+        Directly supplied right-truncation PMF. Python API only.
 
     Returns
     -------
@@ -249,6 +258,9 @@ def main(
         exclude_date_ranges=parsed_exclude_date_ranges,
         credentials_path=credentials_path,
         logger=logger,
+        param_data_dir=param_data_dir,
+        nowcast_source_name=nowcast_source_name,
+        right_truncation_pmf=right_truncation_pmf,
     )
 
     # Step 2: Prepare data for modelling (process location data, epiweekly data)
@@ -329,6 +341,26 @@ if __name__ == "__main__":
             "Type of ED visits to model: 'observed' (disease-related), "
             "'other' (non-disease background), or 'pct' (percentage of total ED visits). "
             "Only applicable for NSSP target (default: observed)."
+        ),
+    )
+
+    parser.add_argument(
+        "--param-data-dir",
+        type=Path,
+        default=Path("private_data", "prod_param_estimates"),
+        help="Directory containing parameter estimates such as right-truncation PMFs.",
+    )
+
+    parser.add_argument(
+        "--nowcast-source",
+        dest="nowcast_source_name",
+        type=str,
+        default="auto",
+        choices=["auto", "none", "right-truncation"],
+        help=(
+            "Nowcast source to use: 'auto' selects the default for the target, "
+            "'none' disables nowcasting, and 'right-truncation' forces "
+            "right-truncation nowcasting where supported (default: auto)."
         ),
     )
 

--- a/pipelines/epiautogp/forecast_spec.py
+++ b/pipelines/epiautogp/forecast_spec.py
@@ -1,0 +1,31 @@
+"""
+Forecast specification value object.
+
+Lives in its own module so that both `nowcast.py` (which the protocol and its
+implementations live in) and `epiautogp_forecast_utils.py` (which builds and
+consumes specs) can import it.
+"""
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(frozen=True)
+class ForecastSpec:
+    """
+    Specification of a single forecast run.
+
+    Bundles the disease, location, vintage, data-source family, cadence, and
+    ED-visit subtype that together identify and parameterize one forecast.
+    These fields travel together through the pipeline and the validation in
+    `prep_epiautogp_data._validate_epiautogp_parameters` enforces relationships
+    between them, so they form a single cohesive unit rather than independent
+    arguments.
+    """
+
+    disease: str
+    loc: str
+    report_date: date
+    target: str
+    frequency: str
+    ed_visit_type: str

--- a/pipelines/epiautogp/nowcast.py
+++ b/pipelines/epiautogp/nowcast.py
@@ -6,7 +6,6 @@ import datetime as dt
 from dataclasses import dataclass, field
 from typing import Protocol
 
-
 @dataclass(frozen=True)
 class NowcastData:
     """
@@ -17,12 +16,12 @@ class NowcastData:
     reports: list[list[float]] = field(default_factory=list)
 
 
-class NowcastModel(Protocol):
+class NowcastSource(Protocol):
     """
-    Interface for models that estimate nowcast data.
+    Interface to getting nowcast data, whether from a fixed source or some estimation procedure.
     """
 
-    def estimate(
+    def get_nowcast_data(
         self,
         *,
         dates: list[dt.date],
@@ -32,3 +31,19 @@ class NowcastModel(Protocol):
         Estimate nowcast data for one model run.
         """
         ...
+
+
+@dataclass(frozen=True)
+class FixedNowcast:
+    data: NowcastData
+
+    def get_nowcast_data(
+        self,
+        *,
+        dates: list[dt.date],
+        reports: list[float],
+    ) -> NowcastData:
+        return self.data
+
+
+

--- a/pipelines/epiautogp/nowcast.py
+++ b/pipelines/epiautogp/nowcast.py
@@ -56,6 +56,7 @@ class FixedNowcast:
     """
     Simple nowcast source that just returns a fixed set of nowcast data
     """
+
     data: NowcastData
 
     @staticmethod

--- a/pipelines/epiautogp/nowcast.py
+++ b/pipelines/epiautogp/nowcast.py
@@ -20,7 +20,24 @@ class NowcastData:
 class NowcastSource(Protocol):
     """
     Interface to getting nowcast data, whether from a fixed source or some estimation procedure.
+
+    A source declares which pipeline configurations it can meaningfully nowcast
+    via `applies_to`. The resolver in `epiautogp_forecast_utils` uses this to
+    decide whether to wire the source into the pipeline (under "auto") or to
+    error out (under explicit selection).
     """
+
+    def applies_to(
+        self,
+        *,
+        target: str,
+        ed_visit_type: str,
+        frequency: str,
+    ) -> bool:
+        """
+        Whether this source is applicable to a particular pipeline configuration.
+        """
+        ...
 
     def get_nowcast_data(
         self,
@@ -37,6 +54,15 @@ class NowcastSource(Protocol):
 @dataclass(frozen=True)
 class FixedNowcast:
     data: NowcastData
+
+    @staticmethod
+    def applies_to(
+        *,
+        target: str,
+        ed_visit_type: str,
+        frequency: str,
+    ) -> bool:
+        return True
 
     def get_nowcast_data(
         self,

--- a/pipelines/epiautogp/nowcast.py
+++ b/pipelines/epiautogp/nowcast.py
@@ -4,14 +4,13 @@ Generic nowcast objects for EpiAutoGP.
 
 import datetime as dt
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Protocol
 
 
 @dataclass(frozen=True)
 class NowcastData:
     """
-    Dates and report series for EpiAutoGP nowcasting.
+    Dates and report series for nowcasting.
     """
 
     dates: list[dt.date] = field(default_factory=list)
@@ -20,22 +19,16 @@ class NowcastData:
 
 class NowcastModel(Protocol):
     """
-    Interface for models that estimate EpiAutoGP nowcast data.
+    Interface for models that estimate nowcast data.
     """
 
     def estimate(
         self,
         *,
-        combined_data_path: Path | str,
-        disease: str,
-        loc: str,
-        report_date: dt.date,
-        frequency: str,
-        ed_visit_type: str,
-        exclude_date_ranges: list[tuple[dt.date, dt.date]] | None = None,
+        dates: list[dt.date],
+        reports: list[float],
     ) -> NowcastData:
         """
-        Estimate nowcast data for one EpiAutoGP model run.
+        Estimate nowcast data for one model run.
         """
         ...
-

--- a/pipelines/epiautogp/nowcast.py
+++ b/pipelines/epiautogp/nowcast.py
@@ -6,6 +6,8 @@ import datetime as dt
 from dataclasses import dataclass, field
 from typing import Protocol
 
+from pipelines.epiautogp.forecast_spec import ForecastSpec
+
 
 @dataclass(frozen=True)
 class NowcastData:
@@ -21,8 +23,8 @@ class NowcastSource(Protocol):
     """
     Interface to getting nowcast data, whether from a fixed source or some estimation procedure.
 
-    A source declares which pipeline configurations it can meaningfully nowcast
-    via `applies_to`. The resolver in `epiautogp_forecast_utils` uses this to
+    A source declares which pipeline configurations it can meaningfully nowcast with a particular nowcasting
+    approach via `applies_to`. The resolver in `epiautogp_forecast_utils` uses this to
     decide whether to wire the source into the pipeline (under "auto") or to
     error out (under explicit selection).
     """
@@ -30,9 +32,7 @@ class NowcastSource(Protocol):
     def applies_to(
         self,
         *,
-        target: str,
-        ed_visit_type: str,
-        frequency: str,
+        forecast_spec: ForecastSpec,
     ) -> bool:
         """
         Whether this source is applicable to a particular pipeline configuration.
@@ -53,14 +53,15 @@ class NowcastSource(Protocol):
 
 @dataclass(frozen=True)
 class FixedNowcast:
+    """
+    Simple nowcast source that just returns a fixed set of nowcast data
+    """
     data: NowcastData
 
     @staticmethod
     def applies_to(
         *,
-        target: str,
-        ed_visit_type: str,
-        frequency: str,
+        forecast_spec: ForecastSpec,
     ) -> bool:
         return True
 

--- a/pipelines/epiautogp/nowcast.py
+++ b/pipelines/epiautogp/nowcast.py
@@ -1,0 +1,41 @@
+"""
+Generic nowcast objects for EpiAutoGP.
+"""
+
+import datetime as dt
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class NowcastData:
+    """
+    Dates and report series for EpiAutoGP nowcasting.
+    """
+
+    dates: list[dt.date] = field(default_factory=list)
+    reports: list[list[float]] = field(default_factory=list)
+
+
+class NowcastModel(Protocol):
+    """
+    Interface for models that estimate EpiAutoGP nowcast data.
+    """
+
+    def estimate(
+        self,
+        *,
+        combined_data_path: Path | str,
+        disease: str,
+        loc: str,
+        report_date: dt.date,
+        frequency: str,
+        ed_visit_type: str,
+        exclude_date_ranges: list[tuple[dt.date, dt.date]] | None = None,
+    ) -> NowcastData:
+        """
+        Estimate nowcast data for one EpiAutoGP model run.
+        """
+        ...
+

--- a/pipelines/epiautogp/nowcast.py
+++ b/pipelines/epiautogp/nowcast.py
@@ -6,6 +6,7 @@ import datetime as dt
 from dataclasses import dataclass, field
 from typing import Protocol
 
+
 @dataclass(frozen=True)
 class NowcastData:
     """
@@ -44,6 +45,3 @@ class FixedNowcast:
         reports: list[float],
     ) -> NowcastData:
         return self.data
-
-
-

--- a/pipelines/epiautogp/nssp_nowcast.py
+++ b/pipelines/epiautogp/nssp_nowcast.py
@@ -19,7 +19,7 @@ class NsspRightTruncationNowcast:
 
     right_truncation_pmf: list[float]
 
-    def estimate(
+    def get_nowcast_data(
         self,
         *,
         dates: list[dt.date],

--- a/pipelines/epiautogp/nssp_nowcast.py
+++ b/pipelines/epiautogp/nssp_nowcast.py
@@ -54,10 +54,7 @@ class NsspRightTruncationNowcast:
         ):
             report = float(report)
             if fraction < 0.0:
-                raise ValueError(
-                    "Reporting fraction must be nonnegative: "
-                    f"{fraction}"
-                )
+                raise ValueError(f"Reporting fraction must be nonnegative: {fraction}")
             if fraction == 0.0:
                 if report == 0.0:
                     nowcast_estimates.append(0.0)
@@ -65,8 +62,6 @@ class NsspRightTruncationNowcast:
                 raise ValueError(
                     "Cannot nowcast a positive report with zero reporting fraction"
                 )
-            nowcast_estimates.append(
-                (report + 1.0 - fraction) / fraction
-            )
+            nowcast_estimates.append((report + 1.0 - fraction) / fraction)
 
         return NowcastData(dates=nowcast_dates, reports=[nowcast_estimates])

--- a/pipelines/epiautogp/nssp_nowcast.py
+++ b/pipelines/epiautogp/nssp_nowcast.py
@@ -1,0 +1,72 @@
+"""
+NSSP right-truncation nowcasting for EpiAutoGP.
+"""
+
+import datetime as dt
+from dataclasses import dataclass
+from itertools import accumulate
+
+from pipelines.epiautogp.nowcast import NowcastData
+
+REPORTING_FRACTION_TOL = 1e-9
+
+
+@dataclass(frozen=True)
+class NsspRightTruncationNowcast:
+    """
+    Estimate NSSP nowcasts from PyRenew-style right-truncation PMFs.
+    """
+
+    right_truncation_pmf: list[float]
+
+    def estimate(
+        self,
+        *,
+        dates: list[dt.date],
+        reports: list[float],
+    ) -> NowcastData:
+        """
+        Apply right-truncation correction to one daily NSSP time series.
+        """
+        if len(dates) != len(reports):
+            raise ValueError("dates and reports must have the same length")
+
+        # The right-truncation PMF has no explicit resolution metadata;
+        # its support is daily reporting delay by convention.
+        right_truncation_cdf = list(accumulate(self.right_truncation_pmf))
+        incomplete_cdf = [
+            fraction
+            for fraction in right_truncation_cdf
+            if fraction < 1.0 - REPORTING_FRACTION_TOL
+        ]
+
+        n_nowcast = min(len(reports), len(incomplete_cdf))
+        if n_nowcast == 0:
+            return NowcastData()
+
+        # Well behaved estimate when cases are zero, see:
+        # https://baselinenowcast.epinowcast.org/articles/model_definition.html#point-nowcast-generation
+        nowcast_dates = dates[-n_nowcast:]
+        nowcast_estimates = []
+        for report, fraction in zip(
+            reports[-n_nowcast:],
+            reversed(incomplete_cdf[-n_nowcast:]),
+        ):
+            report = float(report)
+            if fraction < 0.0:
+                raise ValueError(
+                    "Reporting fraction must be nonnegative: "
+                    f"{fraction}"
+                )
+            if fraction == 0.0:
+                if report == 0.0:
+                    nowcast_estimates.append(0.0)
+                    continue
+                raise ValueError(
+                    "Cannot nowcast a positive report with zero reporting fraction"
+                )
+            nowcast_estimates.append(
+                (report + 1.0 - fraction) / fraction
+            )
+
+        return NowcastData(dates=nowcast_dates, reports=[nowcast_estimates])

--- a/pipelines/epiautogp/nssp_nowcast.py
+++ b/pipelines/epiautogp/nssp_nowcast.py
@@ -1,23 +1,47 @@
 """
 NSSP right-truncation nowcasting for EpiAutoGP.
+
+The estimator inflates the most-recent observations of a daily count series by
+the inverse of the reporting CDF. It is only meaningful for *count* targets:
+applied to a percentage (numerator / denominator) the same inflation factor
+would multiply both terms and cancel out, so the source declares itself
+inapplicable to `ed_visit_type="pct"`. Producing useful percentage nowcasts
+would require distinct PMFs for the numerator and denominator series (see
+#1058).
 """
 
 import datetime as dt
 from dataclasses import dataclass
-from itertools import accumulate
 
 from pipelines.epiautogp.nowcast import NowcastData
-
-REPORTING_FRACTION_TOL = 1e-9
+from pipelines.epiautogp.reporting_delay import (
+    inflate_report,
+    reporting_inflation_factors,
+)
 
 
 @dataclass(frozen=True)
 class NsspRightTruncationNowcast:
     """
-    Estimate NSSP nowcasts from PyRenew-style right-truncation PMFs.
+    Estimate NSSP nowcasts from PyRenew-style reporting-delay PMFs.
+
+    The PMF support is daily reporting delay by convention; that is the source
+    of the `frequency="daily"` requirement in `applies_to`.
     """
 
-    right_truncation_pmf: list[float]
+    reporting_delay_pmf: list[float]
+
+    @staticmethod
+    def applies_to(
+        *,
+        target: str,
+        ed_visit_type: str,
+        frequency: str,
+    ) -> bool:
+        return (
+            target == "nssp"
+            and ed_visit_type in ("observed", "other")
+        )
 
     def get_nowcast_data(
         self,
@@ -31,37 +55,19 @@ class NsspRightTruncationNowcast:
         if len(dates) != len(reports):
             raise ValueError("dates and reports must have the same length")
 
-        # The right-truncation PMF has no explicit resolution metadata;
-        # its support is daily reporting delay by convention.
-        right_truncation_cdf = list(accumulate(self.right_truncation_pmf))
-        incomplete_cdf = [
-            fraction
-            for fraction in right_truncation_cdf
-            if fraction < 1.0 - REPORTING_FRACTION_TOL
-        ]
+        incomplete_fractions = reporting_inflation_factors(self.reporting_delay_pmf)
 
-        n_nowcast = min(len(reports), len(incomplete_cdf))
+        n_nowcast = min(len(reports), len(incomplete_fractions))
         if n_nowcast == 0:
             return NowcastData()
 
-        # Well behaved estimate when cases are zero, see:
-        # https://baselinenowcast.epinowcast.org/articles/model_definition.html#point-nowcast-generation
         nowcast_dates = dates[-n_nowcast:]
-        nowcast_estimates = []
-        for report, fraction in zip(
-            reports[-n_nowcast:],
-            reversed(incomplete_cdf[-n_nowcast:]),
-        ):
-            report = float(report)
-            if fraction < 0.0:
-                raise ValueError(f"Reporting fraction must be nonnegative: {fraction}")
-            if fraction == 0.0:
-                if report == 0.0:
-                    nowcast_estimates.append(0.0)
-                    continue
-                raise ValueError(
-                    "Cannot nowcast a positive report with zero reporting fraction"
-                )
-            nowcast_estimates.append((report + 1.0 - fraction) / fraction)
+        nowcast_estimates = [
+            inflate_report(float(report), fraction)
+            for report, fraction in zip(
+                reports[-n_nowcast:],
+                reversed(incomplete_fractions[-n_nowcast:]),
+            )
+        ]
 
         return NowcastData(dates=nowcast_dates, reports=[nowcast_estimates])

--- a/pipelines/epiautogp/prep_epiautogp_data.py
+++ b/pipelines/epiautogp/prep_epiautogp_data.py
@@ -16,6 +16,7 @@ from pipelines.epiautogp.epiautogp_forecast_utils import (
     ForecastPipelineContext,
     ModelPaths,
 )
+from pipelines.epiautogp.nowcast import NowcastData
 
 
 def _validate_epiautogp_parameters(
@@ -55,11 +56,43 @@ def _validate_epiautogp_parameters(
         )
 
 
+def _generate_nowcast_data(
+    context: ForecastPipelineContext,
+    dates: list[dt.date],
+    reports: list[float],
+) -> NowcastData:
+    """
+    Generate nowcast data using the provided nowcast source.
+
+    If context.nowcast_source is None, returns empty NowcastData.
+    Otherwise, calls the get_nowcast_data method of the nowcast source.
+
+    Parameters
+    ----------
+    context : ForecastPipelineContext
+        Forecast pipeline context containing the nowcast source
+    dates : list[dt.date]
+        List of dates corresponding to the observed reports
+    reports : list[float]
+        List of observed report values corresponding to the dates
+
+    Returns
+    -------
+    NowcastData
+        NowcastData object containing nowcast dates and reports
+    """
+    if context.nowcast_source is None:
+        return NowcastData()
+
+    return context.nowcast_source.get_nowcast_data(
+        dates=dates,
+        reports=reports,
+    )
+
+
 def convert_to_epiautogp_json(
     context: ForecastPipelineContext,
     paths: ModelPaths,
-    nowcast_dates: list[dt.date] | None = None,
-    nowcast_reports: list[list[float]] | None = None,
 ) -> Path:
     """
     Convert surveillance data to EpiAutoGP JSON format.
@@ -76,12 +109,6 @@ def convert_to_epiautogp_json(
     paths : ModelPaths
         Model paths containing daily and epiweekly training data paths,
         and model_output_dir where the JSON file will be saved
-    nowcast_dates : list[dt.date] | `None`, default=`None`
-        Dates requiring nowcasting (typically recent dates with
-        incomplete data). If `None`, defaults to empty list. Not currently used.
-    nowcast_reports : list[list[float]] | `None`, default=`None`
-        Samples for nowcast dates to represent nowcast uncertainty. If `None`,
-        defaults to empty list. Not currently used.
 
     Returns
     -------
@@ -124,12 +151,6 @@ def convert_to_epiautogp_json(
         context.target, context.frequency, context.ed_visit_type
     )
 
-    # Set defaults for nowcasting
-    if nowcast_dates is None:
-        nowcast_dates = []
-    if nowcast_reports is None:
-        nowcast_reports = []
-
     # Define input data JSON path
     input_json_path = paths.model_output_dir / f"{context.model_name}_input.json"
     # Determine which data path to use based on frequency
@@ -148,6 +169,14 @@ def convert_to_epiautogp_json(
         logger,
     )
 
+    # Generate nowcast data from the provided nowcast source in the context (if any)
+    if context.nowcast_source is not None:
+        logger.info(
+            "Generating nowcast data using nowcast source type "
+            f"{type(context.nowcast_source).__name__}"
+        )
+    nowcast_data = _generate_nowcast_data(context, dates, reports)
+
     # Create EpiAutoGP input structure
     epiautogp_input = {
         "dates": [d.isoformat() for d in dates],
@@ -158,8 +187,8 @@ def convert_to_epiautogp_json(
         "frequency": context.frequency,
         "ed_visit_type": context.ed_visit_type,
         "forecast_date": context.report_date.isoformat(),
-        "nowcast_dates": [d.isoformat() for d in nowcast_dates],
-        "nowcast_reports": nowcast_reports,
+        "nowcast_dates": [d.isoformat() for d in nowcast_data.dates],
+        "nowcast_reports": nowcast_data.reports,
     }
 
     # Write JSON file

--- a/pipelines/epiautogp/prep_epiautogp_data.py
+++ b/pipelines/epiautogp/prep_epiautogp_data.py
@@ -145,11 +145,10 @@ def convert_to_epiautogp_json(
     }
     """
     logger = context.logger
+    forecast_spec = context.forecast_spec
 
     # Validate parameters
-    _validate_epiautogp_parameters(
-        context.target, context.frequency, context.ed_visit_type
-    )
+    _validate_epiautogp_parameters(forecast_spec.target, forecast_spec.frequency, forecast_spec.ed_visit_type)
 
     # Define input data JSON path
     input_json_path = paths.model_output_dir / f"{context.model_name}_input.json"
@@ -157,14 +156,14 @@ def convert_to_epiautogp_json(
     data_path = paths.training_data
 
     # Read data from TSV
-    logger.info(f"Reading {context.frequency} data from {data_path}")
+    logger.info(f"Reading {forecast_spec.frequency} data from {data_path}")
     dates, reports = _read_tsv_data(
         data_path,
-        context.disease,
-        context.loc,
-        context.target,
-        context.frequency,
-        context.ed_visit_type,
+        forecast_spec.disease,
+        forecast_spec.loc,
+        forecast_spec.target,
+        forecast_spec.frequency,
+        forecast_spec.ed_visit_type,
         context.exclude_date_ranges,
         logger,
     )
@@ -181,12 +180,12 @@ def convert_to_epiautogp_json(
     epiautogp_input = {
         "dates": [d.isoformat() for d in dates],
         "reports": reports,
-        "pathogen": context.disease,
-        "location": context.loc,
-        "target": context.target,
-        "frequency": context.frequency,
-        "ed_visit_type": context.ed_visit_type,
-        "forecast_date": context.report_date.isoformat(),
+        "pathogen": forecast_spec.disease,
+        "location": forecast_spec.loc,
+        "target": forecast_spec.target,
+        "frequency": forecast_spec.frequency,
+        "ed_visit_type": forecast_spec.ed_visit_type,
+        "forecast_date": forecast_spec.report_date.isoformat(),
         "nowcast_dates": [d.isoformat() for d in nowcast_data.dates],
         "nowcast_reports": nowcast_data.reports,
     }
@@ -197,8 +196,8 @@ def convert_to_epiautogp_json(
         json.dump(epiautogp_input, f, indent=2)
 
     logger.info(
-        f"Saved EpiAutoGP input JSON for {context.disease} {context.loc} "
-        f"(target={context.target}) to {input_json_path}"
+        f"Saved EpiAutoGP input JSON for {forecast_spec.disease} {forecast_spec.loc} "
+        f"(target={forecast_spec.target}) to {input_json_path}"
     )
 
     return input_json_path

--- a/pipelines/epiautogp/prep_epiautogp_data.py
+++ b/pipelines/epiautogp/prep_epiautogp_data.py
@@ -148,7 +148,9 @@ def convert_to_epiautogp_json(
     forecast_spec = context.forecast_spec
 
     # Validate parameters
-    _validate_epiautogp_parameters(forecast_spec.target, forecast_spec.frequency, forecast_spec.ed_visit_type)
+    _validate_epiautogp_parameters(
+        forecast_spec.target, forecast_spec.frequency, forecast_spec.ed_visit_type
+    )
 
     # Define input data JSON path
     input_json_path = paths.model_output_dir / f"{context.model_name}_input.json"

--- a/pipelines/epiautogp/reporting_delay.py
+++ b/pipelines/epiautogp/reporting_delay.py
@@ -1,0 +1,40 @@
+"""
+Reporting-delay helpers shared across nowcast sources.
+"""
+
+from itertools import accumulate
+
+REPORTING_FRACTION_TOL = 1e-9
+
+
+def reporting_inflation_factors(pmf: list[float]) -> list[float]:
+    """
+    Per-row reporting fractions for the most-recent observations.
+
+    The reporting-delay PMF is converted to a CDF; entries strictly less than 1
+    correspond to dates whose reports are still partial. Returns those CDF
+    entries in order (oldest-first), so callers can pair them with the
+    most-recent observations (newest-first) to inflate toward fully-reported
+    counts.
+    """
+    cdf = list(accumulate(pmf))
+    return [fraction for fraction in cdf if fraction < 1.0 - REPORTING_FRACTION_TOL]
+
+
+def inflate_report(report: float, fraction: float) -> float:
+    """
+    Inflation estimator for one partially-reported observation.
+
+    Implements the zero-handling approximation documented at
+    https://baselinenowcast.epinowcast.org/articles/model_definition.html#point-nowcast-generation
+    so a zero report with a small reporting fraction stays well-behaved.
+    """
+    if fraction < 0.0:
+        raise ValueError(f"Reporting fraction must be nonnegative: {fraction}")
+    if fraction == 0.0:
+        if report == 0.0:
+            return 0.0
+        raise ValueError(
+            "Cannot inflate a positive report with zero reporting fraction"
+        )
+    return (report + 1.0 - fraction) / fraction

--- a/pipelines/epiautogp/reporting_delay_nowcast.py
+++ b/pipelines/epiautogp/reporting_delay_nowcast.py
@@ -11,6 +11,7 @@ would require distinct PMFs for the numerator and denominator series (see
 """
 
 import datetime as dt
+import logging
 from dataclasses import dataclass
 
 from pipelines.epiautogp.nowcast import NowcastData
@@ -18,6 +19,8 @@ from pipelines.epiautogp.reporting_delay import (
     inflate_report,
     reporting_inflation_factors,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -43,6 +46,13 @@ class ReportingDelayNowcast:
         # both terms and cancels, so reject ed_visit_type="pct". Target and
         # frequency are not gating conditions: any count series can be
         # corrected when paired with a PMF on its native cadence.
+        if frequency != "daily":
+            logger.warning(
+                "Using reporting-delay nowcasting for frequency=%r. Confirm "
+                "the reporting-delay PMF support matches the model cadence.",
+                frequency,
+            )
+
         return ed_visit_type != "pct"
 
     def get_nowcast_data(

--- a/pipelines/epiautogp/reporting_delay_nowcast.py
+++ b/pipelines/epiautogp/reporting_delay_nowcast.py
@@ -1,5 +1,5 @@
 """
-NSSP right-truncation nowcasting for EpiAutoGP.
+Reporting-delay nowcasting for EpiAutoGP.
 
 The estimator inflates the most-recent observations of a daily count series by
 the inverse of the reporting CDF. It is only meaningful for *count* targets:
@@ -21,12 +21,12 @@ from pipelines.epiautogp.reporting_delay import (
 
 
 @dataclass(frozen=True)
-class NsspRightTruncationNowcast:
+class ReportingDelayNowcast:
     """
-    Estimate NSSP nowcasts from PyRenew-style reporting-delay PMFs.
+    Estimate nowcasts by inflating recent observations with a reporting-delay PMF.
 
-    The PMF support is daily reporting delay by convention; that is the source
-    of the `frequency="daily"` requirement in `applies_to`.
+    The PMF support is daily reporting delay by convention; the resolver logs a
+    soft warning if used with a non-daily series.
     """
 
     reporting_delay_pmf: list[float]
@@ -34,14 +34,16 @@ class NsspRightTruncationNowcast:
     @staticmethod
     def applies_to(
         *,
-        target: str,
-        ed_visit_type: str,
-        frequency: str,
+        target: str = "nssp",
+        ed_visit_type: str = "observed",
+        frequency: str = "daily",
     ) -> bool:
-        return (
-            target == "nssp"
-            and ed_visit_type in ("observed", "other")
-        )
+        # The estimator multiplies recent observations by 1/reporting_fraction.
+        # For a percentage (numerator / denominator) the same factor applies to
+        # both terms and cancels, so reject ed_visit_type="pct". Target and
+        # frequency are not gating conditions: any count series can be
+        # corrected when paired with a PMF on its native cadence.
+        return ed_visit_type != "pct"
 
     def get_nowcast_data(
         self,
@@ -50,7 +52,7 @@ class NsspRightTruncationNowcast:
         reports: list[float],
     ) -> NowcastData:
         """
-        Apply right-truncation correction to one daily NSSP time series.
+        Apply reporting-delay inflation to one daily time series.
         """
         if len(dates) != len(reports):
             raise ValueError("dates and reports must have the same length")

--- a/pipelines/epiautogp/reporting_delay_nowcast.py
+++ b/pipelines/epiautogp/reporting_delay_nowcast.py
@@ -14,12 +14,12 @@ import datetime as dt
 import logging
 from dataclasses import dataclass
 
+from pipelines.epiautogp.forecast_spec import ForecastSpec
 from pipelines.epiautogp.nowcast import NowcastData
 from pipelines.epiautogp.reporting_delay import (
     inflate_report,
     reporting_inflation_factors,
 )
-from pipelines.epiautogp.forecast_spec import ForecastSpec
 
 logger = logging.getLogger(__name__)
 

--- a/pipelines/epiautogp/reporting_delay_nowcast.py
+++ b/pipelines/epiautogp/reporting_delay_nowcast.py
@@ -19,6 +19,7 @@ from pipelines.epiautogp.reporting_delay import (
     inflate_report,
     reporting_inflation_factors,
 )
+from pipelines.epiautogp.forecast_spec import ForecastSpec
 
 logger = logging.getLogger(__name__)
 
@@ -37,23 +38,21 @@ class ReportingDelayNowcast:
     @staticmethod
     def applies_to(
         *,
-        target: str = "nssp",
-        ed_visit_type: str = "observed",
-        frequency: str = "daily",
+        forecast_spec: ForecastSpec,
     ) -> bool:
         # The estimator multiplies recent observations by 1/reporting_fraction.
         # For a percentage (numerator / denominator) the same factor applies to
         # both terms and cancels, so reject ed_visit_type="pct". Target and
         # frequency are not gating conditions: any count series can be
         # corrected when paired with a PMF on its native cadence.
-        if frequency != "daily":
+        if forecast_spec.frequency != "daily":
             logger.warning(
                 "Using reporting-delay nowcasting for frequency=%r. Confirm "
                 "the reporting-delay PMF support matches the model cadence.",
-                frequency,
+                forecast_spec.frequency,
             )
 
-        return ed_visit_type != "pct"
+        return forecast_spec.ed_visit_type != "pct"
 
     def get_nowcast_data(
         self,

--- a/pipelines/tests/test_epiautogp_fit.sh
+++ b/pipelines/tests/test_epiautogp_fit.sh
@@ -26,6 +26,7 @@ cmd_args=(
 	--disease "$disease"
 	--loc "$location"
 	--facility-level-nssp-data-dir "$BASE_DIR/private_data/nssp_etl_gold"
+	--param-data-dir "$BASE_DIR/private_data/prod_param_estimates"
 	--output-dir "$BASE_DIR/2024-12-21_forecasts"
 	--n-training-days 90
 	--target "$target"

--- a/pipelines/tests/test_epiautogp_fit.sh
+++ b/pipelines/tests/test_epiautogp_fit.sh
@@ -45,6 +45,13 @@ if [ "$ed_visit_type" != "observed" ]; then
 	cmd_args+=(--ed-visit-type "$ed_visit_type")
 fi
 
+# NSSP counts use the test-data reporting-delay PMF; NHSN and NSSP
+# percentages have no nowcast (the reporting-delay estimator only applies
+# to count series).
+if [ "$target" = "nssp" ] && [ "$ed_visit_type" != "pct" ]; then
+	cmd_args+=(--nowcast-source reporting-delay)
+fi
+
 uv run python pipelines/epiautogp/forecast_epiautogp.py "${cmd_args[@]}"
 
 if [ "$?" -ne 0 ]; then

--- a/pipelines/tests/test_forecast_utils.py
+++ b/pipelines/tests/test_forecast_utils.py
@@ -25,6 +25,7 @@ import pytest
 
 from pipelines.epiautogp.epiautogp_forecast_utils import (
     ForecastPipelineContext,
+    ForecastSpec,
     ModelPaths,
     _resolve_nowcast_source,
     setup_forecast_pipeline,
@@ -40,14 +41,16 @@ def base_context(tmp_path):
     Tests can use this directly or override specific fields as needed.
     """
     return ForecastPipelineContext(
-        disease="COVID-19",
-        loc="CA",
-        target="nssp",
-        frequency="epiweekly",
-        ed_visit_type="observed",
+        forecast_spec=ForecastSpec(
+            disease="COVID-19",
+            loc="CA",
+            report_date=dt.date(2024, 12, 20),
+            target="nssp",
+            frequency="epiweekly",
+            ed_visit_type="observed",
+        ),
         model_name="test_model",
         nhsn_data_path=None,
-        report_date=dt.date(2024, 12, 20),
         first_training_date=dt.date(2024, 9, 22),
         last_training_date=dt.date(2024, 12, 20),
         n_forecast_days=28,
@@ -67,14 +70,16 @@ class TestForecastPipelineContext:
     def test_context_initialization(self):
         """Test that ForecastPipelineContext can be initialized with all fields."""
         context = ForecastPipelineContext(
-            disease="COVID-19",
-            loc="CA",
-            target="nssp",
-            frequency="epiweekly",
-            ed_visit_type="observed",
+            forecast_spec=ForecastSpec(
+                disease="COVID-19",
+                loc="CA",
+                report_date=dt.date(2024, 12, 20),
+                target="nssp",
+                frequency="epiweekly",
+                ed_visit_type="observed",
+            ),
             model_name="test_model",
             nhsn_data_path=None,
-            report_date=dt.date(2024, 12, 20),
             first_training_date=dt.date(2024, 9, 22),
             last_training_date=dt.date(2024, 12, 20),
             n_forecast_days=28,
@@ -87,8 +92,8 @@ class TestForecastPipelineContext:
             logger=logging.getLogger(),
         )
 
-        assert context.disease == "COVID-19"
-        assert context.loc == "CA"
+        assert context.forecast_spec.disease == "COVID-19"
+        assert context.forecast_spec.loc == "CA"
         assert context.n_forecast_days == 28
         assert context.exclude_last_n_days == 0
         assert context.exclude_date_ranges is None
@@ -278,50 +283,56 @@ class TestSetupForecastPipeline:
 
     def test_reporting_delay_errors_for_percentage_targets(self):
         """Test reporting-delay fails for percentage data (numerator/denominator)."""
+        spec = ForecastSpec(
+            disease="COVID-19",
+            loc="CA",
+            report_date=dt.date(2024, 12, 20),
+            target="nssp",
+            frequency="daily",
+            ed_visit_type="pct",
+        )
         with pytest.raises(ValueError, match="not applicable"):
             _resolve_nowcast_source(
-                disease="COVID-19",
-                loc="CA",
-                target="nssp",
-                frequency="daily",
-                ed_visit_type="pct",
-                report_date=dt.date(2024, 12, 20),
+                forecast_spec=spec,
                 param_data_dir=None,
                 nowcast_source_name="reporting-delay",
                 reporting_delay_pmf=[1.0],
-                logger=logging.getLogger(),
             )
 
     def test_reporting_delay_applies_to_nhsn_counts(self):
         """Test reporting-delay also applies to NHSN counts (not just NSSP)."""
-        result = _resolve_nowcast_source(
+        spec = ForecastSpec(
             disease="COVID-19",
             loc="CA",
+            report_date=dt.date(2024, 12, 20),
             target="nhsn",
             frequency="daily",
             ed_visit_type="observed",
-            report_date=dt.date(2024, 12, 20),
+        )
+        result = _resolve_nowcast_source(
+            forecast_spec=spec,
             param_data_dir=None,
             nowcast_source_name="reporting-delay",
             reporting_delay_pmf=[0.4, 0.6],
-            logger=logging.getLogger(),
         )
 
         assert isinstance(result, ReportingDelayNowcast)
 
     def test_reporting_delay_returns_source_for_applicable_config(self):
         """Test reporting-delay builds a source for daily NSSP counts."""
-        result = _resolve_nowcast_source(
+        spec = ForecastSpec(
             disease="COVID-19",
             loc="CA",
+            report_date=dt.date(2024, 12, 20),
             target="nssp",
             frequency="daily",
             ed_visit_type="observed",
-            report_date=dt.date(2024, 12, 20),
+        )
+        result = _resolve_nowcast_source(
+            forecast_spec=spec,
             param_data_dir=None,
             nowcast_source_name="reporting-delay",
             reporting_delay_pmf=[0.4, 0.6],
-            logger=logging.getLogger(),
         )
 
         assert isinstance(result, ReportingDelayNowcast)
@@ -329,18 +340,20 @@ class TestSetupForecastPipeline:
 
     def test_reporting_delay_warns_for_non_daily_frequency(self, caplog):
         """Test reporting-delay logs a soft cadence warning on non-daily runs."""
+        spec = ForecastSpec(
+            disease="COVID-19",
+            loc="CA",
+            report_date=dt.date(2024, 12, 20),
+            target="nssp",
+            frequency="epiweekly",
+            ed_visit_type="observed",
+        )
         with caplog.at_level(logging.WARNING):
             result = _resolve_nowcast_source(
-                disease="COVID-19",
-                loc="CA",
-                target="nssp",
-                frequency="epiweekly",
-                ed_visit_type="observed",
-                report_date=dt.date(2024, 12, 20),
+                forecast_spec=spec,
                 param_data_dir=None,
                 nowcast_source_name="reporting-delay",
                 reporting_delay_pmf=[1.0],
-                logger=logging.getLogger(),
             )
 
         assert isinstance(result, ReportingDelayNowcast)
@@ -348,35 +361,39 @@ class TestSetupForecastPipeline:
 
     def test_none_keyword_returns_no_source(self):
         """Test 'none' resolves to no nowcast source regardless of config."""
-        result = _resolve_nowcast_source(
+        spec = ForecastSpec(
             disease="COVID-19",
             loc="CA",
+            report_date=dt.date(2024, 12, 20),
             target="nssp",
             frequency="daily",
             ed_visit_type="observed",
-            report_date=dt.date(2024, 12, 20),
+        )
+        result = _resolve_nowcast_source(
+            forecast_spec=spec,
             param_data_dir=None,
             nowcast_source_name="none",
             reporting_delay_pmf=[0.5, 0.5],
-            logger=logging.getLogger(),
         )
 
         assert result is None
 
     def test_unknown_keyword_raises(self):
         """Test an unrecognised keyword raises a descriptive error."""
+        spec = ForecastSpec(
+            disease="COVID-19",
+            loc="CA",
+            report_date=dt.date(2024, 12, 20),
+            target="nssp",
+            frequency="daily",
+            ed_visit_type="observed",
+        )
         with pytest.raises(ValueError, match="nowcast_source_name must be one of"):
             _resolve_nowcast_source(
-                disease="COVID-19",
-                loc="CA",
-                target="nssp",
-                frequency="daily",
-                ed_visit_type="observed",
-                report_date=dt.date(2024, 12, 20),
+                forecast_spec=spec,
                 param_data_dir=None,
                 nowcast_source_name="auto",
                 reporting_delay_pmf=None,
-                logger=logging.getLogger(),
             )
 
 
@@ -442,7 +459,7 @@ class TestPrepareModelData:
         # Override just the fields we need for this test
         context = replace(
             base_context,
-            target="nhsn",
+            forecast_spec=replace(base_context.forecast_spec, target="nhsn"),
             nhsn_data_path=nhsn_path,
         )
 
@@ -471,7 +488,7 @@ class TestPrepareModelData:
         # Override multiple fields for NHSN test
         context = replace(
             base_context,
-            target="nhsn",
+            forecast_spec=replace(base_context.forecast_spec, target="nhsn"),
             model_name="epiautogp_nhsn_epiweekly",
             nhsn_data_path=nhsn_path,
             credentials_dict={"key": "value"},

--- a/pipelines/tests/test_forecast_utils.py
+++ b/pipelines/tests/test_forecast_utils.py
@@ -29,7 +29,7 @@ from pipelines.epiautogp.epiautogp_forecast_utils import (
     _resolve_nowcast_source,
     setup_forecast_pipeline,
 )
-from pipelines.epiautogp.nssp_nowcast import NsspRightTruncationNowcast
+from pipelines.epiautogp.reporting_delay_nowcast import ReportingDelayNowcast
 
 
 @pytest.fixture
@@ -197,7 +197,7 @@ class TestSetupForecastPipeline:
     @patch("pipelines.epiautogp.epiautogp_forecast_utils.load_credentials")
     @patch("pipelines.epiautogp.epiautogp_forecast_utils.get_available_reports")
     @patch("pipelines.epiautogp.epiautogp_forecast_utils.calculate_training_dates")
-    def test_auto_nssp_observed_builds_right_truncation_source(
+    def test_reporting_delay_fetches_pmf_from_param_data_dir(
         self,
         mock_calc_dates,
         mock_get_reports,
@@ -206,7 +206,7 @@ class TestSetupForecastPipeline:
         mock_get_pmfs,
         tmp_path,
     ):
-        """Test auto nowcasting builds an NSSP right-truncation source."""
+        """Test reporting-delay nowcasting loads the PMF from param_data_dir."""
         mock_load_creds.return_value = {}
         mock_get_reports.return_value = [dt.date(2024, 12, 20)]
         mock_calc_dates.return_value = (dt.date(2024, 9, 22), dt.date(2024, 12, 20))
@@ -226,10 +226,11 @@ class TestSetupForecastPipeline:
             n_training_days=90,
             n_forecast_days=28,
             param_data_dir=tmp_path / "prod_param_estimates",
+            nowcast_source_name="reporting-delay",
         )
 
-        assert isinstance(context.nowcast_source, NsspRightTruncationNowcast)
-        assert context.nowcast_source.right_truncation_pmf == [0.25, 0.75]
+        assert isinstance(context.nowcast_source, ReportingDelayNowcast)
+        assert context.nowcast_source.reporting_delay_pmf == [0.25, 0.75]
         assert mock_get_pmfs.call_args.kwargs["loc_abb"] == "CA"
         assert mock_get_pmfs.call_args.kwargs["disease"] == "COVID-19"
         assert mock_get_pmfs.call_args.kwargs["as_of"] == dt.date(2024, 12, 20)
@@ -239,7 +240,7 @@ class TestSetupForecastPipeline:
     @patch("pipelines.epiautogp.epiautogp_forecast_utils.load_credentials")
     @patch("pipelines.epiautogp.epiautogp_forecast_utils.get_available_reports")
     @patch("pipelines.epiautogp.epiautogp_forecast_utils.calculate_training_dates")
-    def test_direct_right_truncation_pmf_wins_over_param_data_dir(
+    def test_direct_reporting_delay_pmf_wins_over_param_data_dir(
         self,
         mock_calc_dates,
         mock_get_reports,
@@ -267,70 +268,67 @@ class TestSetupForecastPipeline:
             n_training_days=90,
             n_forecast_days=28,
             param_data_dir=tmp_path / "prod_param_estimates",
-            right_truncation_pmf=[0.4, 0.6],
+            nowcast_source_name="reporting-delay",
+            reporting_delay_pmf=[0.4, 0.6],
         )
 
-        assert isinstance(context.nowcast_source, NsspRightTruncationNowcast)
-        assert context.nowcast_source.right_truncation_pmf == [0.4, 0.6]
+        assert isinstance(context.nowcast_source, ReportingDelayNowcast)
+        assert context.nowcast_source.reporting_delay_pmf == [0.4, 0.6]
         mock_get_pmfs.assert_not_called()
 
-    @pytest.mark.parametrize(
-        ("target", "ed_visit_type"),
-        [
-            ("nssp", "pct"),
-            ("nhsn", "observed"),
-        ],
-    )
-    def test_auto_source_leaves_unsupported_targets_without_nowcast(
-        self,
-        target,
-        ed_visit_type,
-    ):
-        """Test auto selection leaves pct NSSP and NHSN without nowcasts."""
-        result = _resolve_nowcast_source(
-            disease="COVID-19",
-            loc="CA",
-            target=target,
-            frequency="epiweekly",
-            ed_visit_type=ed_visit_type,
-            report_date=dt.date(2024, 12, 20),
-            param_data_dir=None,
-            nowcast_source_name="auto",
-            right_truncation_pmf=None,
-            logger=logging.getLogger(),
-        )
-
-        assert result is None
-
-    @pytest.mark.parametrize(
-        ("target", "ed_visit_type"),
-        [
-            ("nhsn", "observed"),
-            ("nssp", "pct"),
-        ],
-    )
-    def test_forced_right_truncation_errors_for_unsupported_targets(
-        self,
-        target,
-        ed_visit_type,
-    ):
-        """Test forced right-truncation fails for unsupported targets."""
-        with pytest.raises(ValueError):
+    def test_reporting_delay_errors_for_percentage_targets(self):
+        """Test reporting-delay fails for percentage data (numerator/denominator)."""
+        with pytest.raises(ValueError, match="not applicable"):
             _resolve_nowcast_source(
                 disease="COVID-19",
                 loc="CA",
-                target=target,
+                target="nssp",
                 frequency="daily",
-                ed_visit_type=ed_visit_type,
+                ed_visit_type="pct",
                 report_date=dt.date(2024, 12, 20),
                 param_data_dir=None,
-                nowcast_source_name="right-truncation",
-                right_truncation_pmf=[1.0],
+                nowcast_source_name="reporting-delay",
+                reporting_delay_pmf=[1.0],
                 logger=logging.getLogger(),
             )
 
-    def test_right_truncation_warns_for_non_daily_frequency(self, caplog):
-        """Test right-truncation logs a cadence warning for non-daily runs."""
+    def test_reporting_delay_applies_to_nhsn_counts(self):
+        """Test reporting-delay also applies to NHSN counts (not just NSSP)."""
+        result = _resolve_nowcast_source(
+            disease="COVID-19",
+            loc="CA",
+            target="nhsn",
+            frequency="daily",
+            ed_visit_type="observed",
+            report_date=dt.date(2024, 12, 20),
+            param_data_dir=None,
+            nowcast_source_name="reporting-delay",
+            reporting_delay_pmf=[0.4, 0.6],
+            logger=logging.getLogger(),
+        )
+
+        assert isinstance(result, ReportingDelayNowcast)
+
+    def test_reporting_delay_returns_source_for_applicable_config(self):
+        """Test reporting-delay builds a source for daily NSSP counts."""
+        result = _resolve_nowcast_source(
+            disease="COVID-19",
+            loc="CA",
+            target="nssp",
+            frequency="daily",
+            ed_visit_type="observed",
+            report_date=dt.date(2024, 12, 20),
+            param_data_dir=None,
+            nowcast_source_name="reporting-delay",
+            reporting_delay_pmf=[0.4, 0.6],
+            logger=logging.getLogger(),
+        )
+
+        assert isinstance(result, ReportingDelayNowcast)
+        assert result.reporting_delay_pmf == [0.4, 0.6]
+
+    def test_reporting_delay_warns_for_non_daily_frequency(self, caplog):
+        """Test reporting-delay logs a soft cadence warning on non-daily runs."""
         with caplog.at_level(logging.WARNING):
             result = _resolve_nowcast_source(
                 disease="COVID-19",
@@ -340,13 +338,46 @@ class TestSetupForecastPipeline:
                 ed_visit_type="observed",
                 report_date=dt.date(2024, 12, 20),
                 param_data_dir=None,
-                nowcast_source_name="right-truncation",
-                right_truncation_pmf=[1.0],
+                nowcast_source_name="reporting-delay",
+                reporting_delay_pmf=[1.0],
                 logger=logging.getLogger(),
             )
 
-        assert isinstance(result, NsspRightTruncationNowcast)
-        assert "Confirm that the right-truncation PMF is indexed" in caplog.text
+        assert isinstance(result, ReportingDelayNowcast)
+        assert "reporting-delay PMF support matches the model cadence" in caplog.text
+
+    def test_none_keyword_returns_no_source(self):
+        """Test 'none' resolves to no nowcast source regardless of config."""
+        result = _resolve_nowcast_source(
+            disease="COVID-19",
+            loc="CA",
+            target="nssp",
+            frequency="daily",
+            ed_visit_type="observed",
+            report_date=dt.date(2024, 12, 20),
+            param_data_dir=None,
+            nowcast_source_name="none",
+            reporting_delay_pmf=[0.5, 0.5],
+            logger=logging.getLogger(),
+        )
+
+        assert result is None
+
+    def test_unknown_keyword_raises(self):
+        """Test an unrecognised keyword raises a descriptive error."""
+        with pytest.raises(ValueError, match="nowcast_source_name must be one of"):
+            _resolve_nowcast_source(
+                disease="COVID-19",
+                loc="CA",
+                target="nssp",
+                frequency="daily",
+                ed_visit_type="observed",
+                report_date=dt.date(2024, 12, 20),
+                param_data_dir=None,
+                nowcast_source_name="auto",
+                reporting_delay_pmf=None,
+                logger=logging.getLogger(),
+            )
 
 
 class TestPrepareModelData:

--- a/pipelines/tests/test_forecast_utils.py
+++ b/pipelines/tests/test_forecast_utils.py
@@ -26,8 +26,10 @@ import pytest
 from pipelines.epiautogp.epiautogp_forecast_utils import (
     ForecastPipelineContext,
     ModelPaths,
+    _resolve_nowcast_source,
     setup_forecast_pipeline,
 )
+from pipelines.epiautogp.nssp_nowcast import NsspRightTruncationNowcast
 
 
 @pytest.fixture
@@ -144,6 +146,7 @@ class TestSetupForecastPipeline:
             exclude_last_n_days=0,
             credentials_path=None,
             logger=None,
+            nowcast_source_name="none",
         )
 
         assert isinstance(context, ForecastPipelineContext)
@@ -178,6 +181,7 @@ class TestSetupForecastPipeline:
             output_dir=tmp_path,
             n_training_days=90,
             n_forecast_days=28,
+            nowcast_source_name="none",
         )
 
         expected_batch_dir = (
@@ -187,6 +191,162 @@ class TestSetupForecastPipeline:
 
         assert context.model_batch_dir == expected_batch_dir
         assert context.model_run_dir == expected_run_dir
+
+    @patch("pipelines.epiautogp.epiautogp_forecast_utils.get_pmfs")
+    @patch("pipelines.epiautogp.epiautogp_forecast_utils.pl.scan_parquet")
+    @patch("pipelines.epiautogp.epiautogp_forecast_utils.load_credentials")
+    @patch("pipelines.epiautogp.epiautogp_forecast_utils.get_available_reports")
+    @patch("pipelines.epiautogp.epiautogp_forecast_utils.calculate_training_dates")
+    def test_auto_nssp_observed_builds_right_truncation_source(
+        self,
+        mock_calc_dates,
+        mock_get_reports,
+        mock_load_creds,
+        mock_scan_parquet,
+        mock_get_pmfs,
+        tmp_path,
+    ):
+        """Test auto nowcasting builds an NSSP right-truncation source."""
+        mock_load_creds.return_value = {}
+        mock_get_reports.return_value = [dt.date(2024, 12, 20)]
+        mock_calc_dates.return_value = (dt.date(2024, 9, 22), dt.date(2024, 12, 20))
+        mock_scan_parquet.return_value = pl.LazyFrame()
+        mock_get_pmfs.return_value = {"right_truncation_pmf": [0.25, 0.75]}
+
+        context = setup_forecast_pipeline(
+            disease="COVID-19",
+            loc="CA",
+            target="nssp",
+            frequency="daily",
+            ed_visit_type="observed",
+            model_name="test_model",
+            nhsn_data_path=None,
+            facility_level_nssp_data_dir=tmp_path,
+            output_dir=tmp_path,
+            n_training_days=90,
+            n_forecast_days=28,
+            param_data_dir=tmp_path / "prod_param_estimates",
+        )
+
+        assert isinstance(context.nowcast_source, NsspRightTruncationNowcast)
+        assert context.nowcast_source.right_truncation_pmf == [0.25, 0.75]
+        assert mock_get_pmfs.call_args.kwargs["loc_abb"] == "CA"
+        assert mock_get_pmfs.call_args.kwargs["disease"] == "COVID-19"
+        assert mock_get_pmfs.call_args.kwargs["as_of"] == dt.date(2024, 12, 20)
+
+    @patch("pipelines.epiautogp.epiautogp_forecast_utils.get_pmfs")
+    @patch("pipelines.epiautogp.epiautogp_forecast_utils.pl.scan_parquet")
+    @patch("pipelines.epiautogp.epiautogp_forecast_utils.load_credentials")
+    @patch("pipelines.epiautogp.epiautogp_forecast_utils.get_available_reports")
+    @patch("pipelines.epiautogp.epiautogp_forecast_utils.calculate_training_dates")
+    def test_direct_right_truncation_pmf_wins_over_param_data_dir(
+        self,
+        mock_calc_dates,
+        mock_get_reports,
+        mock_load_creds,
+        mock_scan_parquet,
+        mock_get_pmfs,
+        tmp_path,
+    ):
+        """Test a directly supplied PMF is used without calling get_pmfs."""
+        mock_load_creds.return_value = {}
+        mock_get_reports.return_value = [dt.date(2024, 12, 20)]
+        mock_calc_dates.return_value = (dt.date(2024, 9, 22), dt.date(2024, 12, 20))
+        mock_scan_parquet.return_value = pl.LazyFrame()
+
+        context = setup_forecast_pipeline(
+            disease="COVID-19",
+            loc="CA",
+            target="nssp",
+            frequency="daily",
+            ed_visit_type="other",
+            model_name="test_model",
+            nhsn_data_path=None,
+            facility_level_nssp_data_dir=tmp_path,
+            output_dir=tmp_path,
+            n_training_days=90,
+            n_forecast_days=28,
+            param_data_dir=tmp_path / "prod_param_estimates",
+            right_truncation_pmf=[0.4, 0.6],
+        )
+
+        assert isinstance(context.nowcast_source, NsspRightTruncationNowcast)
+        assert context.nowcast_source.right_truncation_pmf == [0.4, 0.6]
+        mock_get_pmfs.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("target", "ed_visit_type"),
+        [
+            ("nssp", "pct"),
+            ("nhsn", "observed"),
+        ],
+    )
+    def test_auto_source_leaves_unsupported_targets_without_nowcast(
+        self,
+        target,
+        ed_visit_type,
+    ):
+        """Test auto selection leaves pct NSSP and NHSN without nowcasts."""
+        result = _resolve_nowcast_source(
+            disease="COVID-19",
+            loc="CA",
+            target=target,
+            frequency="epiweekly",
+            ed_visit_type=ed_visit_type,
+            report_date=dt.date(2024, 12, 20),
+            param_data_dir=None,
+            nowcast_source_name="auto",
+            right_truncation_pmf=None,
+            logger=logging.getLogger(),
+        )
+
+        assert result is None
+
+    @pytest.mark.parametrize(
+        ("target", "ed_visit_type"),
+        [
+            ("nhsn", "observed"),
+            ("nssp", "pct"),
+        ],
+    )
+    def test_forced_right_truncation_errors_for_unsupported_targets(
+        self,
+        target,
+        ed_visit_type,
+    ):
+        """Test forced right-truncation fails for unsupported targets."""
+        with pytest.raises(ValueError):
+            _resolve_nowcast_source(
+                disease="COVID-19",
+                loc="CA",
+                target=target,
+                frequency="daily",
+                ed_visit_type=ed_visit_type,
+                report_date=dt.date(2024, 12, 20),
+                param_data_dir=None,
+                nowcast_source_name="right-truncation",
+                right_truncation_pmf=[1.0],
+                logger=logging.getLogger(),
+            )
+
+    def test_right_truncation_warns_for_non_daily_frequency(self, caplog):
+        """Test right-truncation logs a cadence warning for non-daily runs."""
+        with caplog.at_level(logging.WARNING):
+            result = _resolve_nowcast_source(
+                disease="COVID-19",
+                loc="CA",
+                target="nssp",
+                frequency="epiweekly",
+                ed_visit_type="observed",
+                report_date=dt.date(2024, 12, 20),
+                param_data_dir=None,
+                nowcast_source_name="right-truncation",
+                right_truncation_pmf=[1.0],
+                logger=logging.getLogger(),
+            )
+
+        assert isinstance(result, NsspRightTruncationNowcast)
+        assert "Confirm that the right-truncation PMF is indexed" in caplog.text
 
 
 class TestPrepareModelData:

--- a/pipelines/tests/test_prep_epiautogp_data.py
+++ b/pipelines/tests/test_prep_epiautogp_data.py
@@ -16,6 +16,7 @@ import pytest
 
 from pipelines.epiautogp.epiautogp_forecast_utils import (
     ForecastPipelineContext,
+    ForecastSpec,
     ModelPaths,
 )
 from pipelines.epiautogp.nowcast import NowcastData
@@ -320,14 +321,16 @@ def _write_combined_data(path):
 
 def _epiautogp_context(tmp_path, nowcast_source=None):
     return ForecastPipelineContext(
-        disease="COVID-19",
-        loc="CA",
-        target="nssp",
-        frequency="daily",
-        ed_visit_type="observed",
+        forecast_spec=ForecastSpec(
+            disease="COVID-19",
+            loc="CA",
+            report_date=dt.date(2024, 1, 3),
+            target="nssp",
+            frequency="daily",
+            ed_visit_type="observed",
+        ),
         model_name="test_model",
         nhsn_data_path=None,
-        report_date=dt.date(2024, 1, 3),
         first_training_date=dt.date(2024, 1, 1),
         last_training_date=dt.date(2024, 1, 2),
         n_forecast_days=28,

--- a/pipelines/tests/test_prep_epiautogp_data.py
+++ b/pipelines/tests/test_prep_epiautogp_data.py
@@ -7,12 +7,22 @@ list-based implementation to ensure correctness.
 """
 
 import datetime as dt
+import json
+import logging
 from unittest.mock import MagicMock
 
 import polars as pl
 import pytest
 
-from pipelines.epiautogp.prep_epiautogp_data import _apply_date_exclusions
+from pipelines.epiautogp.epiautogp_forecast_utils import (
+    ForecastPipelineContext,
+    ModelPaths,
+)
+from pipelines.epiautogp.nowcast import NowcastData
+from pipelines.epiautogp.prep_epiautogp_data import (
+    _apply_date_exclusions,
+    convert_to_epiautogp_json,
+)
 
 N_DAYS = 10
 
@@ -265,3 +275,113 @@ class TestDateExclusionFiltering:
         assert "disease" in filtered_df.columns
         assert all(filtered_df["geo_value"] == "CA")
         assert all(filtered_df["disease"] == "COVID-19")
+
+
+class FakeNowcastSource:
+    """Small test nowcast source that records the model series it receives."""
+
+    def __init__(self):
+        self.dates = None
+        self.reports = None
+
+    def get_nowcast_data(
+        self,
+        *,
+        dates: list[dt.date],
+        reports: list[float],
+    ) -> NowcastData:
+        self.dates = dates
+        self.reports = reports
+        return NowcastData(dates=[dates[-1]], reports=[[reports[-1] + 1.0]])
+
+
+def _write_combined_data(path):
+    pl.DataFrame(
+        [
+            {
+                "date": dt.date(2024, 1, 1),
+                "geo_value": "CA",
+                "disease": "COVID-19",
+                "data_type": "train",
+                ".variable": "observed_ed_visits",
+                ".value": 10.0,
+            },
+            {
+                "date": dt.date(2024, 1, 2),
+                "geo_value": "CA",
+                "disease": "COVID-19",
+                "data_type": "train",
+                ".variable": "observed_ed_visits",
+                ".value": 20.0,
+            },
+        ]
+    ).write_csv(path, separator="\t")
+
+
+def _epiautogp_context(tmp_path, nowcast_source=None):
+    return ForecastPipelineContext(
+        disease="COVID-19",
+        loc="CA",
+        target="nssp",
+        frequency="daily",
+        ed_visit_type="observed",
+        model_name="test_model",
+        nhsn_data_path=None,
+        report_date=dt.date(2024, 1, 3),
+        first_training_date=dt.date(2024, 1, 1),
+        last_training_date=dt.date(2024, 1, 2),
+        n_forecast_days=28,
+        exclude_last_n_days=0,
+        exclude_date_ranges=None,
+        model_batch_dir=tmp_path / "batch",
+        model_run_dir=tmp_path / "batch" / "model_runs" / "CA",
+        credentials_dict={},
+        facility_level_nssp_data=pl.LazyFrame(),
+        logger=logging.getLogger(),
+        nowcast_source=nowcast_source,
+    )
+
+
+class TestConvertToEpiAutoGpJson:
+    """Tests for EpiAutoGP JSON serialization."""
+
+    def test_no_nowcast_source_serializes_empty_nowcast_arrays(self, tmp_path):
+        """Test converter writes empty nowcast arrays without a source."""
+        data_path = tmp_path / "combined_data.tsv"
+        _write_combined_data(data_path)
+        paths = ModelPaths(
+            model_output_dir=tmp_path / "model",
+            data_dir=tmp_path,
+            training_data=data_path,
+        )
+
+        output_path = convert_to_epiautogp_json(
+            context=_epiautogp_context(tmp_path),
+            paths=paths,
+        )
+
+        output = json.loads(output_path.read_text())
+        assert output["nowcast_dates"] == []
+        assert output["nowcast_reports"] == []
+
+    def test_nowcast_source_serializes_nowcast_data(self, tmp_path):
+        """Test converter writes nowcast data supplied by the context source."""
+        data_path = tmp_path / "combined_data.tsv"
+        _write_combined_data(data_path)
+        paths = ModelPaths(
+            model_output_dir=tmp_path / "model",
+            data_dir=tmp_path,
+            training_data=data_path,
+        )
+        source = FakeNowcastSource()
+
+        output_path = convert_to_epiautogp_json(
+            context=_epiautogp_context(tmp_path, nowcast_source=source),
+            paths=paths,
+        )
+
+        output = json.loads(output_path.read_text())
+        assert source.dates == [dt.date(2024, 1, 1), dt.date(2024, 1, 2)]
+        assert source.reports == [10.0, 20.0]
+        assert output["nowcast_dates"] == ["2024-01-02"]
+        assert output["nowcast_reports"] == [[21.0]]

--- a/pipelines/tests/test_reporting_delay_nowcast.py
+++ b/pipelines/tests/test_reporting_delay_nowcast.py
@@ -14,8 +14,9 @@ from pipelines.epiautogp.reporting_delay import (
 from pipelines.epiautogp.reporting_delay_nowcast import ReportingDelayNowcast
 
 
-def _spec(*, target: str = "nssp", ed_visit_type: str = "observed",
-          frequency: str = "daily") -> ForecastSpec:
+def _spec(
+    *, target: str = "nssp", ed_visit_type: str = "observed", frequency: str = "daily"
+) -> ForecastSpec:
     """Build a ForecastSpec varying only the fields applies_to cares about."""
     return ForecastSpec(
         disease="COVID-19",

--- a/pipelines/tests/test_reporting_delay_nowcast.py
+++ b/pipelines/tests/test_reporting_delay_nowcast.py
@@ -5,12 +5,26 @@ import math
 
 import pytest
 
+from pipelines.epiautogp.forecast_spec import ForecastSpec
 from pipelines.epiautogp.nowcast import FixedNowcast, NowcastData
 from pipelines.epiautogp.reporting_delay import (
     inflate_report,
     reporting_inflation_factors,
 )
 from pipelines.epiautogp.reporting_delay_nowcast import ReportingDelayNowcast
+
+
+def _spec(*, target: str = "nssp", ed_visit_type: str = "observed",
+          frequency: str = "daily") -> ForecastSpec:
+    """Build a ForecastSpec varying only the fields applies_to cares about."""
+    return ForecastSpec(
+        disease="COVID-19",
+        loc="CA",
+        report_date=dt.date(2024, 1, 1),
+        target=target,
+        frequency=frequency,
+        ed_visit_type=ed_visit_type,
+    )
 
 
 class TestReportingInflationFactors:
@@ -58,24 +72,11 @@ class TestReportingDelayNowcastAppliesTo:
         ],
     )
     def test_applies_to(self, target, ed_visit_type, expected):
-        # Only ed_visit_type is gating; target and frequency are accepted for
-        # protocol compatibility but ignored. The resolver enforces daily
-        # cadence via a soft warning.
-        assert (
-            ReportingDelayNowcast.applies_to(
-                target=target, ed_visit_type=ed_visit_type, frequency="daily"
-            )
-            is expected
-        )
-
-    def test_applies_to_uses_defaults_for_optional_kwargs(self):
-        # Callers (e.g. an NHSN context where ed_visit_type isn't meaningful)
-        # can rely on the defaults.
-        assert ReportingDelayNowcast.applies_to(target="nhsn") is True
-        assert (
-            ReportingDelayNowcast.applies_to(target="nssp", ed_visit_type="pct")
-            is False
-        )
+        # Only ed_visit_type is gating; target and frequency are carried in the
+        # spec for protocol compatibility but ignored here. The resolver
+        # enforces daily cadence via a soft warning.
+        spec = _spec(target=target, ed_visit_type=ed_visit_type, frequency="daily")
+        assert ReportingDelayNowcast.applies_to(forecast_spec=spec) is expected
 
 
 class TestReportingDelayNowcastGetNowcastData:
@@ -147,10 +148,7 @@ class TestReportingDelayNowcastGetNowcastData:
 
 class TestFixedNowcast:
     def test_applies_to_always_true(self):
-        assert (
-            FixedNowcast.applies_to(target="x", ed_visit_type="y", frequency="z")
-            is True
-        )
+        assert FixedNowcast.applies_to(forecast_spec=_spec()) is True
 
     def test_returns_stored_data(self):
         data = NowcastData(dates=[dt.date(2024, 1, 1)], reports=[[1.0]])

--- a/pipelines/tests/test_reporting_delay_nowcast.py
+++ b/pipelines/tests/test_reporting_delay_nowcast.py
@@ -1,0 +1,165 @@
+"""Unit tests for nowcast sources and reporting-delay helpers."""
+
+import datetime as dt
+import math
+
+import pytest
+
+from pipelines.epiautogp.nowcast import FixedNowcast, NowcastData
+from pipelines.epiautogp.reporting_delay import (
+    inflate_report,
+    reporting_inflation_factors,
+)
+from pipelines.epiautogp.reporting_delay_nowcast import ReportingDelayNowcast
+
+
+class TestReportingInflationFactors:
+    def test_drops_fully_reported_tail(self):
+        # CDF = [0.4, 0.9, 1.0]; the 1.0 is fully reported and dropped.
+        assert reporting_inflation_factors([0.4, 0.5, 0.1]) == pytest.approx([0.4, 0.9])
+
+    def test_all_partial(self):
+        assert reporting_inflation_factors([0.3, 0.4]) == pytest.approx([0.3, 0.7])
+
+    def test_single_complete_bin_yields_empty(self):
+        assert reporting_inflation_factors([1.0]) == []
+
+    def test_empty_pmf(self):
+        assert reporting_inflation_factors([]) == []
+
+
+class TestInflateReport:
+    def test_basic_inflation(self):
+        # (report + 1 - fraction) / fraction; report=4, fraction=0.5
+        assert inflate_report(4.0, 0.5) == pytest.approx((4.0 + 0.5) / 0.5)
+
+    def test_zero_report_with_zero_fraction(self):
+        assert inflate_report(0.0, 0.0) == 0.0
+
+    def test_positive_report_with_zero_fraction_raises(self):
+        with pytest.raises(ValueError, match="zero reporting fraction"):
+            inflate_report(3.0, 0.0)
+
+    def test_negative_fraction_raises(self):
+        with pytest.raises(ValueError, match="nonnegative"):
+            inflate_report(1.0, -0.1)
+
+
+class TestReportingDelayNowcastAppliesTo:
+    @pytest.mark.parametrize(
+        ("target", "ed_visit_type", "expected"),
+        [
+            ("nssp", "observed", True),
+            ("nssp", "other", True),
+            ("nssp", "pct", False),
+            # NHSN has no ed_visit_type concept; the parameter defaults to
+            # "observed" upstream and the source happily applies to its counts.
+            ("nhsn", "observed", True),
+        ],
+    )
+    def test_applies_to(self, target, ed_visit_type, expected):
+        # Only ed_visit_type is gating; target and frequency are accepted for
+        # protocol compatibility but ignored. The resolver enforces daily
+        # cadence via a soft warning.
+        assert (
+            ReportingDelayNowcast.applies_to(
+                target=target, ed_visit_type=ed_visit_type, frequency="daily"
+            )
+            is expected
+        )
+
+    def test_applies_to_uses_defaults_for_optional_kwargs(self):
+        # Callers (e.g. an NHSN context where ed_visit_type isn't meaningful)
+        # can rely on the defaults.
+        assert ReportingDelayNowcast.applies_to(target="nhsn") is True
+        assert (
+            ReportingDelayNowcast.applies_to(target="nssp", ed_visit_type="pct")
+            is False
+        )
+
+
+class TestReportingDelayNowcastGetNowcastData:
+    def test_returns_inflated_estimates_for_partial_tail(self):
+        # PMF = [0.5, 0.5] -> CDF = [0.5, 1.0] -> incomplete = [0.5];
+        # only the most-recent observation gets inflated.
+        source = ReportingDelayNowcast(reporting_delay_pmf=[0.5, 0.5])
+        dates = [dt.date(2024, 1, 1), dt.date(2024, 1, 2), dt.date(2024, 1, 3)]
+        reports = [10.0, 20.0, 4.0]
+
+        result = source.get_nowcast_data(dates=dates, reports=reports)
+
+        assert result.dates == [dt.date(2024, 1, 3)]
+        assert len(result.reports) == 1
+        # inflate_report(4, 0.5) = (4 + 0.5) / 0.5 = 9.0
+        assert result.reports[0] == pytest.approx([9.0])
+
+    def test_two_partial_rows(self):
+        # PMF = [0.4, 0.5, 0.1] -> CDF = [0.4, 0.9, 1.0] -> incomplete = [0.4, 0.9]
+        # Most-recent observation pairs with the smallest fraction (0.4).
+        source = ReportingDelayNowcast(reporting_delay_pmf=[0.4, 0.5, 0.1])
+        dates = [
+            dt.date(2024, 1, 1),
+            dt.date(2024, 1, 2),
+            dt.date(2024, 1, 3),
+            dt.date(2024, 1, 4),
+        ]
+        reports = [10.0, 20.0, 8.0, 4.0]
+
+        result = source.get_nowcast_data(dates=dates, reports=reports)
+
+        assert result.dates == [dt.date(2024, 1, 3), dt.date(2024, 1, 4)]
+        # The older partial row (Jan 3) uses fraction=0.9; the newest (Jan 4) uses 0.4.
+        expected = [
+            (8.0 + 1.0 - 0.9) / 0.9,
+            (4.0 + 1.0 - 0.4) / 0.4,
+        ]
+        assert result.reports[0] == pytest.approx(expected)
+
+    def test_fully_reported_pmf_returns_empty(self):
+        source = ReportingDelayNowcast(reporting_delay_pmf=[1.0])
+        result = source.get_nowcast_data(
+            dates=[dt.date(2024, 1, 1)],
+            reports=[5.0],
+        )
+        assert result == NowcastData()
+
+    def test_length_mismatch_raises(self):
+        source = ReportingDelayNowcast(reporting_delay_pmf=[0.5, 0.5])
+        with pytest.raises(ValueError, match="same length"):
+            source.get_nowcast_data(
+                dates=[dt.date(2024, 1, 1)],
+                reports=[1.0, 2.0],
+            )
+
+    def test_zero_report_with_zero_fraction_returns_zero(self):
+        # If the most-recent reporting fraction were ever 0 with a 0 report,
+        # inflate_report returns 0 rather than dividing by zero.
+        # Construct a PMF whose first incomplete fraction is exactly 0.
+        # This is contrived; the safety path matters more than realism.
+        source = ReportingDelayNowcast(reporting_delay_pmf=[0.0, 1.0])
+        result = source.get_nowcast_data(
+            dates=[dt.date(2024, 1, 1), dt.date(2024, 1, 2)],
+            reports=[5.0, 0.0],
+        )
+        assert result.dates == [dt.date(2024, 1, 2)]
+        assert result.reports[0] == [0.0]
+
+
+class TestFixedNowcast:
+    def test_applies_to_always_true(self):
+        assert (
+            FixedNowcast.applies_to(target="x", ed_visit_type="y", frequency="z")
+            is True
+        )
+
+    def test_returns_stored_data(self):
+        data = NowcastData(dates=[dt.date(2024, 1, 1)], reports=[[1.0]])
+        source = FixedNowcast(data=data)
+        out = source.get_nowcast_data(dates=[dt.date(2024, 5, 1)], reports=[42.0])
+        assert out is data
+
+
+def test_no_nan_in_inflate():
+    # Sanity: typical numbers should not produce NaN/inf.
+    value = inflate_report(7.0, 0.25)
+    assert math.isfinite(value)


### PR DESCRIPTION
This pull request introduces a nowcasting abstraction for `pipelines` models aimed at use by `epiautogp` when doing daily NSSP target forecasts in the _first_ instance, but flexible enough to get extended for other nowcasting approaches/frequencies/targets.

The basic ideas for the nowcasting are:

- `NowcastData`: currently just a list of dates and a list of lists of nowcasts, following the default vector-of-vector approach in `NowcastAutoGP`. Not currently extended to other stratifications except dates.
- `NowcastSource` protocol which defines an interface for `get_nowcast_data` method that has to return a `NowcastData` obj.
- Concrete implementations of the protocol:
  - `FixedNowcast`... this will probably get replaced in resolving #1058 
  - `NsspRightTruncationNowcast`, this implements the standard inflation estimator using a bit of nuance around low values, see https://baselinenowcast.epinowcast.org/articles/model_definition.html#zero-handling-approximation for reference implementation. This is a bit more generic that "NSSP" but I've left NSSP in the name because its pretty hard linked to using the NNH right truncation PMF estimates in the reality of this pipeline.

**Pipeline and API enhancements:**

* Updated the `ForecastPipelineContext` dataclass to include a `nowcast_source` member, and modified `setup_forecast_pipeline` to resolve and attach the nowcast source based on user input and available data.
* Extended the main forecast entry point and CLI (`forecast_epiautogp.py`) to accept `param_data_dir`, `nowcast_source_name`, and `right_truncation_pmf` as parameters and command-line arguments. These get resolved to a particular nowcasting approach.

**Data preparation and JSON output:**

* Refactored the data preparation and JSON conversion logic to generate nowcast data using the resolved nowcast source, and included the resulting nowcast dates and reports in the`epiautogp` input JSON. 

**Imports and public API:**

* Updated module imports and `__all__` in `__init__.py` to expose `NowcastData` and `NowcastSource` for use throughout the pipeline.