### PR TITLE
Require a manual `workflow_dispatch` when you want to push to dagster. 

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -8,7 +8,7 @@ on:
     inputs:
       push_to_dagster:
         type: choice
-        description: "Should the container be pushed to the dagster prod server? (WILL ALWAYS PUSH ON MAIN)"
+        description: "Should the container be pushed to the dagster prod server?"
         options:
           - "no"
           - "yes"
@@ -80,7 +80,7 @@ jobs:
       # Conditional step execution that runs when either:
       # 1. The workflow is triggered on the main branch (refs/heads/main), OR
       # 2. A manual workflow dispatch input 'push_to_dagster' is set to 'yes'
-      if: ${{ github.ref == 'refs/heads/main' || github.event.inputs.push_to_dagster == 'yes' }}
+      if: ${{ github.event.inputs.push_to_dagster == 'yes' }}
       runs-on: ubuntu-latest
       name: Update Dagster Code Location
       permissions:

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -515,6 +515,7 @@ weekly_forecast_upstream_sensor = dg.AutomationConditionSensorDefinition(
 weekly_forecast_fusion_sensor = dg.AutomationConditionSensorDefinition(
     name="WeeklyForecastFusion",
     target=dg.AssetSelection.groups("WeeklyForecastFusion"),
+    minimum_interval_seconds=300,
     use_user_code_server=False,  # does NOT allow custom conditions
 )
 
@@ -586,14 +587,17 @@ weekly_forecast_fusion_asset_args = {
 # They are replaced with true assets in production where
 # other code locations are able to be referenced.
 
-if not is_production:
-    nssp_gold_v1 = dg.AssetSpec(
-        "nssp_gold_v1", partitions_def=daily_partitions_def, group_name="Upstream"
-    )
+nssp_gold_v1 = dg.AssetSpec(
+    "nssp_gold_v1", 
+    partitions_def=daily_partitions_def, 
+    group_name="Upstream"
+)
 
-    nhsn_hrd_prelim = dg.AssetSpec(
-        "nhsn_hrd_prelim", partitions_def=daily_partitions_def, group_name="Upstream"
-    )
+nhsn_hrd_prelim = dg.AssetSpec(
+    "nhsn_hrd_prelim", 
+    partitions_def=daily_partitions_def, 
+    group_name="Upstream"
+)
 
 
 # ---------------- Weekly Forecasts --------------


### PR DESCRIPTION
- Pushes and PRs will never trigger a push to the dagster server.
- Workflow dispatch is the only thing that can trigger a push to the dagster server, and you have to specify that's what you want.