### PR TITLE
Make it so only `workflow_dispatch` and explicit changes to `dagster_defs.py` on `main` can push to dagster

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -76,7 +76,7 @@ jobs:
             cache-to: type=registry,ref=ghcr.io/cdcgov/${{ env.IMAGE_NAME }}:${{ steps.image-tag.outputs.tag }}-cache,mode=max
 
     check_if_dagster_defs_changed:
-      name: Check if Dagster Definitions Changed
+      name: Check if dagster_defs.py Changed
       needs: build-pipeline-image
       runs-on: ubuntu-latest
       permissions:

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -8,7 +8,7 @@ on:
     inputs:
       push_to_dagster:
         type: choice
-        description: "Should the container be pushed to the dagster prod server? (WILL ALWAYS PUSH ON MAIN)"
+        description: "Should the container be pushed to the dagster prod server?"
         options:
           - "no"
           - "yes"
@@ -77,10 +77,9 @@ jobs:
 
     deploy_dagster_code:
       needs: build-pipeline-image
-      # Conditional step execution that runs when either:
-      # 1. The workflow is triggered on the main branch (refs/heads/main), OR
-      # 2. A manual workflow dispatch input 'push_to_dagster' is set to 'yes'
-      if: ${{ github.ref == 'refs/heads/main' || github.event.inputs.push_to_dagster == 'yes' }}
+      # Conditional step execution that runs only when:
+      # A manual workflow dispatch input 'push_to_dagster' is set to 'yes'
+      if: ${{ github.event.inputs.push_to_dagster == 'yes' }}
       runs-on: ubuntu-latest
       name: Update Dagster Code Location
       permissions:

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -97,17 +97,16 @@ jobs:
             if [ "${{ github.event_name }}" = "push" ]; then
               BASE="${{ github.event.before }}"
               HEAD="${{ github.sha }}"
-            else
-              BASE="HEAD~1"
-              HEAD="HEAD"
-            fi
+              CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || true)
+              echo $CHANGED
 
-            CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep '^dagster_defs\.py$' || true)
-            echo $CHANGED
-
-            if [ -n "$CHANGED" ]; then
-              echo "changed=true" >> $GITHUB_OUTPUT
+              if [ -n "$CHANGED" ]; then
+                echo "changed=true" >> $GITHUB_OUTPUT
+              else
+                echo "changed=false" >> $GITHUB_OUTPUT
+              fi
             else
+              echo "Setting 'changed' to false as we only care to check when it's a push."
               echo "changed=false" >> $GITHUB_OUTPUT
             fi
 
@@ -121,6 +120,7 @@ jobs:
         ${{
           ( github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_dagster == 'yes' ) ||
           ( github.event_name == 'push' && github.ref_name == 'main' && needs.check_if_dagster_defs_changed.outputs.changed == 'true' )
+          
         }}
       runs-on: ubuntu-latest
       name: Update Dagster Code Location

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -1,4 +1,4 @@
-name: Create Docker Image and push to dagster
+name: Create Docker Image and optionally deploy to Dagster
 
 on:
   push:

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -111,7 +111,7 @@ jobs:
             fi
 
     deploy_dagster_code:
-      needs: [ build-pipeline-image, check_if_dagster_defs_changed]
+      needs: [ build-pipeline-image, check_if_dagster_defs_changed ]
       # Conditional step execution that runs only when:
       # the workflow is manually dispatched and the 'push_to_dagster' input is set to 'yes'
       # OR
@@ -120,7 +120,6 @@ jobs:
         ${{
           ( github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_dagster == 'yes' ) ||
           ( github.event_name == 'push' && github.ref_name == 'main' && needs.check_if_dagster_defs_changed.outputs.changed == 'true' )
-          
         }}
       runs-on: ubuntu-latest
       name: Update Dagster Code Location

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -120,7 +120,7 @@ jobs:
         ${{
           ( github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_dagster == 'yes' ) ||
           ( github.event_name == 'push' && github.ref_name == 'main' && needs.check_if_dagster_defs_changed.outputs.changed == 'true' )
-          
+
         }}
       runs-on: ubuntu-latest
       name: Update Dagster Code Location

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -76,6 +76,7 @@ jobs:
             cache-to: type=registry,ref=ghcr.io/cdcgov/${{ env.IMAGE_NAME }}:${{ steps.image-tag.outputs.tag }}-cache,mode=max
 
     check_if_dagster_defs_changed:
+      name: Check if Dagster Definitions Changed
       needs: build-pipeline-image
       runs-on: ubuntu-latest
       permissions:

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -82,7 +82,7 @@ jobs:
       # OR
       # the event is a push to main where the dagster_defs_changed
       runs-on: ubuntu-latest
-      name: Update Dagster Code Location
+      name: Check Dagster Changes and Update Prod Server
       permissions:
             contents: read
             packages: write

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -99,6 +99,7 @@ jobs:
             fi
 
             CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep '^dagster_defs\.py$' || true)
+            echo $CHANGED
 
             if [ -n "$CHANGED" ]; then
               echo "changed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -98,8 +98,7 @@ jobs:
               BASE="${{ github.event.before }}"
               HEAD="${{ github.sha }}"
               CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || true)
-              echo $CHANGED
-
+              echo "Dagster defs changed? --> $CHANGED"
               if [ -n "$CHANGED" ]; then
                 echo "changed=true" >> $GITHUB_OUTPUT
               else

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -78,8 +78,8 @@ jobs:
     deploy_dagster_code:
       needs: build-pipeline-image
       # Conditional step execution that runs only when:
-      # A manual workflow dispatch input 'push_to_dagster' is set to 'yes'
-      if: ${{ github.event.inputs.push_to_dagster == 'yes' }}
+      # the workflow is manually dispatched and the 'push_to_dagster' input is set to 'yes'
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_dagster == 'yes' }}
       runs-on: ubuntu-latest
       name: Update Dagster Code Location
       permissions:

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -113,9 +113,9 @@ jobs:
       # OR
       # the event is a push to main where the dagster_defs_changed
       if: >-
-        ${{ 
+        ${{
           ( github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_dagster == 'yes' ) ||
-          ( github.event_name == 'push' && github.ref_name == 'main' && needs.check_if_dagster_defs_changed.outputs.changed == 'true' ) 
+          ( github.event_name == 'push' && github.ref_name == 'main' && needs.check_if_dagster_defs_changed.outputs.changed == 'true' )
         }}
       runs-on: ubuntu-latest
       name: Update Dagster Code Location

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -1,4 +1,4 @@
-name: Create Docker Image
+name: Create Docker Image and push to dagster
 
 on:
   push:
@@ -75,11 +75,48 @@ jobs:
               type=registry,ref=ghcr.io/cdcgov/${{ env.IMAGE_NAME }}:latest-cache
             cache-to: type=registry,ref=ghcr.io/cdcgov/${{ env.IMAGE_NAME }}:${{ steps.image-tag.outputs.tag }}-cache,mode=max
 
-    deploy_dagster_code:
+    check_if_dagster_defs_changed:
       needs: build-pipeline-image
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        packages: write
+      outputs:
+        changed: ${{ steps.dagster_changed.outputs.changed }}
+      steps:
+        - name: Check if dagster defs changed
+          id: dagster_changed
+          shell: bash
+          run: |
+            git fetch origin main --depth=2
+
+            if [ "${{ github.event_name }}" = "push" ]; then
+              BASE="${{ github.event.before }}"
+              HEAD="${{ github.sha }}"
+            else
+              BASE="HEAD~1"
+              HEAD="HEAD"
+            fi
+
+            CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep '^dagster_defs\.py$' || true)
+
+            if [ -n "$CHANGED" ]; then
+              echo "changed=true" >> $GITHUB_OUTPUT
+            else
+              echo "changed=false" >> $GITHUB_OUTPUT
+            fi
+
+    deploy_dagster_code:
+      needs: [ build-pipeline-image, check_if_dagster_defs_changed]
       # Conditional step execution that runs only when:
       # the workflow is manually dispatched and the 'push_to_dagster' input is set to 'yes'
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_dagster == 'yes' }}
+      # OR
+      # the event is a push to main where the dagster_defs_changed
+      if: >-
+        ${{ 
+          ( github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_dagster == 'yes' ) ||
+          ( github.event_name == 'push' && github.ref_name == 'main' && needs.check_if_dagster_defs_changed.outputs.changed == 'true' ) 
+        }}
       runs-on: ubuntu-latest
       name: Update Dagster Code Location
       permissions:

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -85,6 +85,9 @@ jobs:
       outputs:
         changed: ${{ steps.dagster_changed.outputs.changed }}
       steps:
+        - name: Checkout code
+          uses: actions/checkout@v6
+
         - name: Check if dagster defs changed
           id: dagster_changed
           shell: bash

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -74,7 +74,7 @@ jobs:
               type=registry,ref=ghcr.io/cdcgov/${{ env.IMAGE_NAME }}:${{ steps.image-tag.outputs.tag }}-cache
               type=registry,ref=ghcr.io/cdcgov/${{ env.IMAGE_NAME }}:latest-cache
             cache-to: type=registry,ref=ghcr.io/cdcgov/${{ env.IMAGE_NAME }}:${{ steps.image-tag.outputs.tag }}-cache,mode=max
-        
+
     check_and_deploy_dagster_code:
       needs: [ build-pipeline-image ]
       # Conditional step execution that runs only when:
@@ -115,7 +115,7 @@ jobs:
             ${{
               ( github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_dagster == 'yes' ) ||
               ( github.event_name == 'push' && github.ref_name == 'main' && steps.dagster_changed.outputs.changed == 'true' )
-            }} 
+            }}
 
           with:
             github_app_id: ${{ secrets.REPO_CDCENT_ACTOR_APP_ID }}

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -74,16 +74,18 @@ jobs:
               type=registry,ref=ghcr.io/cdcgov/${{ env.IMAGE_NAME }}:${{ steps.image-tag.outputs.tag }}-cache
               type=registry,ref=ghcr.io/cdcgov/${{ env.IMAGE_NAME }}:latest-cache
             cache-to: type=registry,ref=ghcr.io/cdcgov/${{ env.IMAGE_NAME }}:${{ steps.image-tag.outputs.tag }}-cache,mode=max
-
-    check_if_dagster_defs_changed:
-      name: Check if dagster_defs.py Changed
-      needs: build-pipeline-image
+        
+    check_and_deploy_dagster_code:
+      needs: [ build-pipeline-image ]
+      # Conditional step execution that runs only when:
+      # the workflow is manually dispatched and the 'push_to_dagster' input is set to 'yes'
+      # OR
+      # the event is a push to main where the dagster_defs_changed
       runs-on: ubuntu-latest
+      name: Update Dagster Code Location
       permissions:
-        contents: read
-        packages: write
-      outputs:
-        changed: ${{ steps.dagster_changed.outputs.changed }}
+            contents: read
+            packages: write
       steps:
         - name: Checkout code
           uses: actions/checkout@v6
@@ -92,8 +94,6 @@ jobs:
           id: dagster_changed
           shell: bash
           run: |
-            git fetch origin main --depth=2
-
             if [ "${{ github.event_name }}" = "push" ]; then
               BASE="${{ github.event.before }}"
               HEAD="${{ github.sha }}"
@@ -109,25 +109,13 @@ jobs:
               echo "changed=false" >> $GITHUB_OUTPUT
             fi
 
-    deploy_dagster_code:
-      needs: [ build-pipeline-image, check_if_dagster_defs_changed ]
-      # Conditional step execution that runs only when:
-      # the workflow is manually dispatched and the 'push_to_dagster' input is set to 'yes'
-      # OR
-      # the event is a push to main where the dagster_defs_changed
-      if: >-
-        ${{
-          ( github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_dagster == 'yes' ) ||
-          ( github.event_name == 'push' && github.ref_name == 'main' && needs.check_if_dagster_defs_changed.outputs.changed == 'true' )
-        }}
-      runs-on: ubuntu-latest
-      name: Update Dagster Code Location
-      permissions:
-            contents: read
-            packages: write
-      steps:
         - name: Run update script with cfa runner-action
           uses: CDCgov/cfa-actions/runner-action@v1.5.0
+          if: >-
+            ${{
+              ( github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_dagster == 'yes' ) ||
+              ( github.event_name == 'push' && github.ref_name == 'main' && steps.dagster_changed.outputs.changed == 'true' )
+            }} 
 
           with:
             github_app_id: ${{ secrets.REPO_CDCENT_ACTOR_APP_ID }}

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ From our [production dagster server](https://dagster.apps.edav.ext.cdc.gov/), yo
 - It is good practice to periodically re-sync (`uv sync`) and even re-create your virtual environment if your branch has been open a while to make sure dependencies are up to date. `cfa-dagster`, our own implementation of dagster, updates frequently. To specifically update that package, run `uv lock --upgrade-package cfa-dagster`.
 
 #### How to push to the dagster server
-1. You can use the Github Actions workflow in `containers.yaml` via workflow dispatch. Use this for testing in pre-prod with a non-`main` branch. 
+1. You can use the Github Actions workflow in `containers.yaml` via workflow dispatch. Use this for testing in pre-prod with a non-`main` branch.
     - Let people know when you do this so they don't override you text with their own.
 2. As mentioned, pushes to main that target `dagster_defs.py` will push to the server.
-3. Powerusers: `make prod_test` will push your own local branch to the server. Communicate that you are running this command to the STF team before doing so. 
+3. Powerusers: `make prod_test` will push your own local branch to the server. Communicate that you are running this command to the STF team before doing so.
 
 ## General Disclaimer
 This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/organization/mission.htm).  GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise.

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ From our [production dagster server](https://dagster.apps.edav.ext.cdc.gov/), yo
     - Let people know when you do this so they don't override you text with their own.
     - Pushes to main that do not include changes to the `dagster_defs.py` file will NOT automatically update the server.
 2. As mentioned, pushes to main that target `dagster_defs.py` will push to the server.
-3. Powerusers: `make prod_test` will build and push your own local branch to the server. 
-    - Communicate that you are running this command to the STF team before doing so. 
+3. Powerusers: `make prod_test` will build and push your own local branch to the server.
+    - Communicate that you are running this command to the STF team before doing so.
 
 ## General Disclaimer
 This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/organization/mission.htm).  GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ From our [production dagster server](https://dagster.apps.edav.ext.cdc.gov/), yo
 #### How to push to the dagster server
 1. You can use the Github Actions workflow in `containers.yaml` via workflow dispatch. Use this for testing in pre-prod with a non-`main` branch. 
     - Let people know when you do this so they don't override you text with their own.
+    - Pushes to main that do not include changes to the `dagster_defs.py` file will NOT automatically update the server.
 2. As mentioned, pushes to main that target `dagster_defs.py` will push to the server.
-3. Powerusers: `make prod_test` will push your own local branch to the server. Communicate that you are running this command to the STF team before doing so. 
+3. Powerusers: `make prod_test` will build and push your own local branch to the server. 
+    - Communicate that you are running this command to the STF team before doing so. 
 
 ## General Disclaimer
 This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/organization/mission.htm).  GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise.

--- a/README.md
+++ b/README.md
@@ -63,14 +63,20 @@ If you'd like to test a few "tasks" locally, you can have dagster execute on you
 
 When using the `Docker Executor`, Dagster assumes mounts at `./blobfuse/mounts/` in the working directory.
 - `make mount`: mounts the pyrenew-relevant blobs using blobfuse. Use this before launching locally-executed dagster jobs.
-- `make unmount`: gracefully unmounts the pyrenew-relevant blobs.
+- `make unmount`: gracefully unmounts the pyrenew-relevant bslobs.
 
 #### Production Scheduling
 
 From our [production dagster server](https://dagster.apps.edav.ext.cdc.gov/), you can run and schedule model runs and see other projects' pipelines at CFA.
-- Pushes to main will automatically update this server via a Github Actions Workflow.
+- Pushes to `main` that include changes to `dagster_defs.py` will automatically update this server via a Github Actions Workflow. (See next section.)
 - Before pushing to `main`, make sure you have thoroughly tested your own branch and gotten a PR review.
 - It is good practice to periodically re-sync (`uv sync`) and even re-create your virtual environment if your branch has been open a while to make sure dependencies are up to date. `cfa-dagster`, our own implementation of dagster, updates frequently. To specifically update that package, run `uv lock --upgrade-package cfa-dagster`.
+
+#### How to push to the dagster server
+1. You can use the Github Actions workflow in `containers.yaml` via workflow dispatch. Use this for testing in pre-prod with a non-`main` branch. 
+    - Let people know when you do this so they don't override you text with their own.
+2. As mentioned, pushes to main that target `dagster_defs.py` will push to the server.
+3. Powerusers: `make prod_test` will push your own local branch to the server. Communicate that you are running this command to the STF team before doing so. 
 
 ## General Disclaimer
 This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/organization/mission.htm).  GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ From our [production dagster server](https://dagster.apps.edav.ext.cdc.gov/), yo
 
 #### How to push to the dagster server
 1. You can use the Github Actions workflow in `containers.yaml` via workflow dispatch. Use this for testing in pre-prod with a non-`main` branch.
-    - Let people know when you do this so they don't override you text with their own.
+    - Let people know when you do this so they don't override your test with their own.
     - Pushes to main that do not include changes to the `dagster_defs.py` file will NOT automatically update the server.
 2. As mentioned, pushes to main that target `dagster_defs.py` will push to the server.
 3. Powerusers: `make prod_test` will build and push your own local branch to the server.


### PR DESCRIPTION
Unchanged:
- Pushes will still build images.

Pushes to dagster will trigger on two possible scenarios:
- You use `workflow_dispatch` and you explicitly select that you'll push to dagster.
- The push is to `main` and `dagster_defs.py` has been updated.

Pushes to main that don't include changes to `dagster_defs.py` will no longer push to dagster.