### PR TITLE
Hotfix: fixing the logic to detect if `dagster_defs.py` changed in `containers.yaml`

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -121,7 +121,7 @@ jobs:
               echo "changed=false" >> $GITHUB_OUTPUT
             fi
 
-            echo "Dagster defs changed?" 
+            echo "Dagster defs changed?"
             echo "->" && echo "$CHANGED"
 
         - name: Run update script with cfa runner-action

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -89,23 +89,24 @@ jobs:
       steps:
         - name: Checkout code
           uses: actions/checkout@v6
+          with:
+            fetch-depth: 0
 
         - name: Check if dagster defs changed
           id: dagster_changed
           shell: bash
           run: |
-            if [ "${{ github.event_name }}" = "push" ]; then
-              BASE="${{ github.event.before }}"
-              HEAD="${{ github.sha }}"
-              CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || true)
-              echo "Dagster defs changed? --> $CHANGED"
-              if [ -n "$CHANGED" ]; then
-                echo "changed=true" >> $GITHUB_OUTPUT
-              else
-                echo "changed=false" >> $GITHUB_OUTPUT
-              fi
+            
+            # Check to see if dagster defs changed since before this PR or push happened
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+            CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || true)
+
+            echo "Dagster defs changed? --> $CHANGED"
+          
+            if [ -n "$CHANGED" ]; then
+              echo "changed=true" >> $GITHUB_OUTPUT
             else
-              echo "Setting 'changed' to false as we only care to check when it's a push."
               echo "changed=false" >> $GITHUB_OUTPUT
             fi
 

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -6,6 +6,14 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
+      build_image:
+        type: choice
+        description: "Should the container be built?"
+        options:
+          - "yes"
+          - "no"
+        default:
+          - "yes"
       push_to_dagster:
         type: choice
         description: "Should the container be pushed to the dagster prod server?"
@@ -27,6 +35,7 @@ jobs:
       name: Build image
       outputs:
         tag: ${{ steps.image-tag.outputs.tag }}
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build_image == 'yes' }}
       steps:
 
         - name: Checkout code
@@ -97,8 +106,13 @@ jobs:
           shell: bash
           run: |
             
-            # Check to see if dagster defs changed since before this PR or push happened
-            BASE="${{ github.event.before }}"
+            # Check to see if dagster defs changed since before this PR or push happened    
+            if [ "${{ github.event_name }}" == "push" ]; then
+              BASE="${{ github.event.before }}"
+            else
+              BASE="${{ github.event.pull_request.base.ref }}"
+            fi
+
             HEAD="${{ github.sha }}"
             CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || true)
 

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -113,15 +113,15 @@ jobs:
             fi
 
             HEAD="${{ github.sha }}"
-            CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || "true")
-
-            echo "Dagster defs changed? --> ${CHANGED}"
+            CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || true)
 
             if [ -n "$CHANGED" ]; then
               echo "changed=true" >> $GITHUB_OUTPUT
             else
               echo "changed=false" >> $GITHUB_OUTPUT
             fi
+
+            echo "Dagster defs changed? --> ${CHANGED}"
 
         - name: Run update script with cfa runner-action
           uses: CDCgov/cfa-actions/runner-action@v1.5.0

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -104,13 +104,14 @@ jobs:
 
         - name: Check if dagster defs changed
           id: dagster_changed
+          if: ${{ github.event_name == "push" || github.event_name == "pull_request" }}
           shell: bash
           run: |
 
             # Check to see if dagster defs changed since before this PR or push happened
             if [ "${{ github.event_name }}" == "push" ]; then
               BASE="${{ github.event.before }}"
-            else
+            elif [ "${{ github.event_name }}" == "pull_request" ]; then
               BASE="${{ github.event.pull_request.base.sha }}"
             fi
 

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -34,7 +34,6 @@ jobs:
       name: Build image
       outputs:
         tag: ${{ steps.image-tag.outputs.tag }}
-      if: ${{ github.event.inputs.build_image != 'no' }}
       steps:
 
         - name: Checkout code
@@ -56,6 +55,7 @@ jobs:
             fi
 
         - name: Docker Login
+          if: ${{ github.event.inputs.build_image != 'no' }}
           uses: docker/login-action@v4
           with:
             registry: ghcr.io
@@ -63,10 +63,12 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Set up Docker Buildx
+          if: ${{ github.event.inputs.build_image != 'no' }}
           id: buildx
           uses: docker/setup-buildx-action@v4
 
         - name: Docker build and push
+          if: ${{ github.event.inputs.build_image != 'no' }}
           uses: docker/build-push-action@v7
           with:
             context: .

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -119,9 +119,9 @@ jobs:
             CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || true)
 
             if [ -n "$CHANGED" ]; then
-              echo "changed=true" >> $GITHUB_OUTPUT
+              echo "changed='true'" >> $GITHUB_OUTPUT
             else
-              echo "changed=false" >> $GITHUB_OUTPUT
+              echo "changed='false'" >> $GITHUB_OUTPUT
             fi
 
             echo "Dagster defs changed?"

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -34,7 +34,7 @@ jobs:
       name: Build image
       outputs:
         tag: ${{ steps.image-tag.outputs.tag }}
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build_image == 'yes' }}
+      if: ${{ github.event.inputs.build_image != 'no' }}
       steps:
 
         - name: Checkout code

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -124,7 +124,7 @@ jobs:
             fi
 
             echo "Dagster defs changed?"
-            echo "->" && echo "$CHANGED"
+            echo "->" && echo "$changed"
 
         - name: Run update script with cfa runner-action
           uses: CDCgov/cfa-actions/runner-action@v1.5.0

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -105,8 +105,8 @@ jobs:
           id: dagster_changed
           shell: bash
           run: |
-            
-            # Check to see if dagster defs changed since before this PR or push happened    
+
+            # Check to see if dagster defs changed since before this PR or push happened
             if [ "${{ github.event_name }}" == "push" ]; then
               BASE="${{ github.event.before }}"
             else

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -12,8 +12,7 @@ on:
         options:
           - "yes"
           - "no"
-        default:
-          - "yes"
+        default: "yes"
       push_to_dagster:
         type: choice
         description: "Should the container be pushed to the dagster prod server?"

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -107,25 +107,21 @@ jobs:
           if: github.event_name == 'push' || github.event_name == 'pull_request'
           shell: bash
           run: |
-
-            # Check to see if dagster defs changed since before this PR or push happened
             if [ "${{ github.event_name }}" == "push" ]; then
               BASE="${{ github.event.before }}"
-            elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            else
               BASE="${{ github.event.pull_request.base.sha }}"
             fi
 
             HEAD="${{ github.sha }}"
-            CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || true)
 
-            if [ -n "$CHANGED" ]; then
-              echo "changed='true'" >> $GITHUB_OUTPUT
+            if git diff --name-only "$BASE" "$HEAD" | grep -q 'dagster_defs\.py'; then
+              echo "changed=true" >> $GITHUB_OUTPUT
+              echo "Dagster defs changed: true"
             else
-              echo "changed='false'" >> $GITHUB_OUTPUT
+              echo "changed=false" >> $GITHUB_OUTPUT
+              echo "Dagster defs changed: false"
             fi
-
-            echo "Dagster defs changed?"
-            echo "->" && echo "$changed"
 
         - name: Run update script with cfa runner-action
           uses: CDCgov/cfa-actions/runner-action@v1.5.0

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -96,14 +96,14 @@ jobs:
           id: dagster_changed
           shell: bash
           run: |
-            
+
             # Check to see if dagster defs changed since before this PR or push happened
             BASE="${{ github.event.before }}"
             HEAD="${{ github.sha }}"
             CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || true)
 
             echo "Dagster defs changed? --> $CHANGED"
-          
+
             if [ -n "$CHANGED" ]; then
               echo "changed=true" >> $GITHUB_OUTPUT
             else

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -104,7 +104,7 @@ jobs:
 
         - name: Check if dagster defs changed
           id: dagster_changed
-          if: ${{ github.event_name == "push" || github.event_name == "pull_request" }}
+          if: github.event_name == 'push' || github.event_name == 'pull_request'
           shell: bash
           run: |
 

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -113,9 +113,9 @@ jobs:
             fi
 
             HEAD="${{ github.sha }}"
-            CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || true)
+            CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep 'dagster_defs\.py' || "true")
 
-            echo "Dagster defs changed? --> $CHANGED"
+            echo "Dagster defs changed? --> ${CHANGED}"
 
             if [ -n "$CHANGED" ]; then
               echo "changed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -55,7 +55,7 @@ jobs:
             fi
 
         - name: Docker Login
-          if: ${{ github.event.inputs.build_image != 'no' }}
+          if: github.event.inputs.build_image != 'no'
           uses: docker/login-action@v4
           with:
             registry: ghcr.io
@@ -63,12 +63,12 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Set up Docker Buildx
-          if: ${{ github.event.inputs.build_image != 'no' }}
+          if: github.event.inputs.build_image != 'no'
           id: buildx
           uses: docker/setup-buildx-action@v4
 
         - name: Docker build and push
-          if: ${{ github.event.inputs.build_image != 'no' }}
+          if: github.event.inputs.build_image != 'no'
           uses: docker/build-push-action@v7
           with:
             context: .
@@ -126,10 +126,8 @@ jobs:
         - name: Run update script with cfa runner-action
           uses: CDCgov/cfa-actions/runner-action@v1.5.0
           if: >-
-            ${{
               ( github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_dagster == 'yes' ) ||
               ( github.event_name == 'push' && github.ref_name == 'main' && steps.dagster_changed.outputs.changed == 'true' )
-            }}
 
           with:
             github_app_id: ${{ secrets.REPO_CDCENT_ACTOR_APP_ID }}

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -109,7 +109,7 @@ jobs:
             if [ "${{ github.event_name }}" == "push" ]; then
               BASE="${{ github.event.before }}"
             else
-              BASE="${{ github.event.pull_request.base.ref }}"
+              BASE="${{ github.event.pull_request.base.sha }}"
             fi
 
             HEAD="${{ github.sha }}"

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -121,7 +121,8 @@ jobs:
               echo "changed=false" >> $GITHUB_OUTPUT
             fi
 
-            echo "Dagster defs changed? --> ${CHANGED}"
+            echo "Dagster defs changed?" 
+            echo "->" && echo "$CHANGED"
 
         - name: Run update script with cfa runner-action
           uses: CDCgov/cfa-actions/runner-action@v1.5.0

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -515,6 +515,7 @@ weekly_forecast_upstream_sensor = dg.AutomationConditionSensorDefinition(
 weekly_forecast_fusion_sensor = dg.AutomationConditionSensorDefinition(
     name="WeeklyForecastFusion",
     target=dg.AssetSelection.groups("WeeklyForecastFusion"),
+    minimum_interval_seconds=300,
     use_user_code_server=False,  # does NOT allow custom conditions
 )
 
@@ -586,14 +587,17 @@ weekly_forecast_fusion_asset_args = {
 # They are replaced with true assets in production where
 # other code locations are able to be referenced.
 
-if not is_production:
-    nssp_gold_v1 = dg.AssetSpec(
-        "nssp_gold_v1", partitions_def=daily_partitions_def, group_name="Upstream"
-    )
+nssp_gold_v1 = dg.AssetSpec(
+    "nssp_gold_v1", 
+    partitions_def=daily_partitions_def, 
+    group_name="Upstream"
+)
 
-    nhsn_hrd_prelim = dg.AssetSpec(
-        "nhsn_hrd_prelim", partitions_def=daily_partitions_def, group_name="Upstream"
-    )
+nhsn_hrd_prelim = dg.AssetSpec(
+    "nhsn_hrd_prelim", 
+    partitions_def=daily_partitions_def, 
+    group_name="Upstream"
+)
 
 
 # ---------------- Weekly Forecasts --------------

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -597,6 +597,7 @@ nhsn_hrd_prelim = dg.AssetSpec(
 
 # ---------------- Weekly Forecasts --------------
 
+
 # Timeseries E
 @dynamic_graph_asset(
     **weekly_forecast_upstream_asset_args,

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -597,7 +597,7 @@ nhsn_hrd_prelim = dg.AssetSpec(
 
 # ---------------- Weekly Forecasts --------------
 
-
+# TEST CHANGE FOR GITHUB ACTIONS
 # Timeseries E
 @dynamic_graph_asset(
     **weekly_forecast_upstream_asset_args,

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -515,7 +515,6 @@ weekly_forecast_upstream_sensor = dg.AutomationConditionSensorDefinition(
 weekly_forecast_fusion_sensor = dg.AutomationConditionSensorDefinition(
     name="WeeklyForecastFusion",
     target=dg.AssetSelection.groups("WeeklyForecastFusion"),
-    minimum_interval_seconds=300,
     use_user_code_server=False,  # does NOT allow custom conditions
 )
 

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -588,15 +588,11 @@ weekly_forecast_fusion_asset_args = {
 # other code locations are able to be referenced.
 
 nssp_gold_v1 = dg.AssetSpec(
-    "nssp_gold_v1", 
-    partitions_def=daily_partitions_def, 
-    group_name="Upstream"
+    "nssp_gold_v1", partitions_def=daily_partitions_def, group_name="Upstream"
 )
 
 nhsn_hrd_prelim = dg.AssetSpec(
-    "nhsn_hrd_prelim", 
-    partitions_def=daily_partitions_def, 
-    group_name="Upstream"
+    "nhsn_hrd_prelim", partitions_def=daily_partitions_def, group_name="Upstream"
 )
 
 

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -597,7 +597,6 @@ nhsn_hrd_prelim = dg.AssetSpec(
 
 # ---------------- Weekly Forecasts --------------
 
-# TEST CHANGE FOR GITHUB ACTIONS
 # Timeseries E
 @dynamic_graph_asset(
     **weekly_forecast_upstream_asset_args,


### PR DESCRIPTION
One condition for the new dagster code location deployment workflow is whether the `dagster_defs.py` file changed.
I noticed this wasn't working properly because it wasn't detecting far back enough (i.e. right before the branch was checked out). I also tightened up the control flow a bit.

- Git fetch depth is now set to unlimited.
- We now log more robustly when the `dagster_defs.py` does or does not change.
- You can now skip an image build if it was just built but you hadn't pushed to dagster and now you'd like to.