### PR TITLE
Set Azure HTTP Policy Logs to WARNING level; reduce clutter in model output

### DIFF
--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -1,5 +1,6 @@
 # Basic Imports
 import datetime as dt
+import logging
 import os
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -733,6 +734,14 @@ storage_account = "cfadagster" if is_production else "cfadagsterdev"
 
 # collect Dagster definitions from the current file
 collected_defs = collect_definitions(globals())
+
+# Set Azure HTTP Logging Level
+# this will limit excessive IO logs in stderr 
+# for any assets making azure http requests
+azure_http_logger = logging.getLogger(
+    "azure.core.pipeline.policies.http_logging_policy"
+)
+azure_http_logger.setLevel(logging.WARNING) 
 
 # Create Definitions object
 defs = dg.Definitions(

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -736,12 +736,12 @@ storage_account = "cfadagster" if is_production else "cfadagsterdev"
 collected_defs = collect_definitions(globals())
 
 # Set Azure HTTP Logging Level
-# this will limit excessive IO logs in stderr 
+# this will limit excessive IO logs in stderr
 # for any assets making azure http requests
 azure_http_logger = logging.getLogger(
     "azure.core.pipeline.policies.http_logging_policy"
 )
-azure_http_logger.setLevel(logging.WARNING) 
+azure_http_logger.setLevel(logging.WARNING)
 
 # Create Definitions object
 defs = dg.Definitions(

--- a/uv.lock
+++ b/uv.lock
@@ -773,8 +773,8 @@ dependencies = [
 
 [[package]]
 name = "cfa-dagster"
-version = "1.0.0"
-source = { git = "https://github.com/cdcgov/cfa-dagster.git?rev=main#dbb6a4459d68b5d2b5c52440cd594d87b5a1b451" }
+version = "1.2.0"
+source = { git = "https://github.com/cdcgov/cfa-dagster.git?rev=main#a9642010bf51828c23f2fe07ef92936081635705" }
 dependencies = [
     { name = "aiofiles" },
     { name = "azure-batch" },


### PR DESCRIPTION
By setting the Azure Core HTTP Policy Logger to `WARNING`, we can suppress unnecessarily verbose logs in our model outputs.

## Pyrenew-e run examples:
### Before, with Azure HTTP Logs:
<img width="924" height="537" alt="image" src="https://github.com/user-attachments/assets/7e59d065-4d1a-4274-bf8d-14b9c555b945" />


### After, with only app logs:
<img width="972" height="521" alt="image" src="https://github.com/user-attachments/assets/886847be-5988-4af2-a8fb-aa916816dea2" />
