### PR TITLE
Update DESCRIPTION remove hubUtils branch

### DIFF
--- a/stfroutineforecasting/DESCRIPTION
+++ b/stfroutineforecasting/DESCRIPTION
@@ -46,7 +46,7 @@ Additional_repositories: https://hubverse-org.r-universe.dev
 Remotes:
     github::cdcgov/forecasttools,
     github::mjskay/ggdist,
-    hubUtils=github::hubverse-org/hubUtils@perf-convert-output-type-282
+    hubUtils=github::hubverse-org/hubUtils
 Suggests:
     checkmate,
     rcmdcheck,


### PR DESCRIPTION
I ran into this error when trying to build the latest Docker image:

```
#18 14.66 Error: #18 14.66 ! error in pak subprocess
#18 14.66 Caused by error:
#18 14.66 ! Could not solve package dependencies:
#18 14.66 * local::/cfa-stf-routine-forecasting/stfroutineforecasting: Can't install dependency hubUtils=github::hubverse-org/hubUtils@perf-convert-output-type-282
#18 14.66 * hubUtils=github::hubverse-org/hubUtils@perf-convert-output-type-282: ! pkgdepends resolution error for
#18 14.66 hubUtils=github::hubverse-org/hubUtils@perf-convert-output-type-282.
#18 14.66 Caused by error:
#18 14.66 ! Can't find reference @perf-convert-output-type-282 in GitHub repo hubverse-org/hubUtils.
```
ChatGPT had this to say:

> The key error is:
> 
> Can't find reference @perf-convert-output-type-282 in GitHub repo hubverse-org/hubUtils
> 
> This is not a Docker or pak problem. It means that stfroutineforecasting depends on a GitHub branch (or tag) that no longer exists.
> 
> Specifically, somewhere in stfroutineforecasting (likely its DESCRIPTION) you have something like
> 
> Config/Needs/...
>     hubUtils=github::hubverse-org/hubUtils@perf-convert-output-type-282
> 
> or
> 
> Remotes:
>     hubverse-org/hubUtils@perf-convert-output-type-282

I removed `@perf-conver-output-type-282` from the hubUtils dependency and everything built as we shall hopefully see in CI for this PR.