### PR TITLE
Use Python append prop data helper

### DIFF
--- a/pipelines/tests/utils/test_common_utils.py
+++ b/pipelines/tests/utils/test_common_utils.py
@@ -5,8 +5,8 @@ import datetime as dt
 import logging
 
 import polars as pl
-import polars.testing as plt
 import pytest
+from polars.testing import assert_frame_equal
 
 from pipelines.utils.cli_utils import (
     add_common_forecast_arguments,
@@ -162,7 +162,7 @@ class TestDataWranglingUtils:
                 ".value": [2.0, 8.0, 0.2],
             }
         )
-        plt.assert_frame_equal(result, expected)
+        assert_frame_equal(result, expected)
 
     def test_append_prop_data_to_combined_data_allows_variable_names(self, tmp_path):
         data_path = tmp_path / "combined_data.tsv"
@@ -195,7 +195,7 @@ class TestDataWranglingUtils:
                 ".value": [7.0, 3.0, 0.3],
             }
         )
-        plt.assert_frame_equal(result, expected)
+        assert_frame_equal(result, expected)
 
 
 class TestCLIUtils:

--- a/pipelines/tests/utils/test_common_utils.py
+++ b/pipelines/tests/utils/test_common_utils.py
@@ -4,6 +4,8 @@ import argparse
 import datetime as dt
 import logging
 
+import polars as pl
+import polars.testing as plt
 import pytest
 
 from pipelines.utils.cli_utils import (
@@ -11,6 +13,7 @@ from pipelines.utils.cli_utils import (
     run_command,
 )
 from pipelines.utils.common_utils import (
+    append_prop_data_to_combined_data,
     calculate_training_dates,
     get_available_reports,
     load_credentials,
@@ -132,6 +135,34 @@ class TestDataWranglingUtils:
         assert dt.date(2024, 12, 1) in result
         assert dt.date(2024, 12, 15) in result
         assert dt.date(2024, 12, 20) in result
+
+    def test_append_prop_data_to_combined_data_updates_tsv(self, tmp_path):
+        data_path = tmp_path / "combined_data.tsv"
+        pl.DataFrame(
+            {
+                "date": ["2024-01-01", "2024-01-01"],
+                "location": ["US", "US"],
+                ".variable": ["observed_ed_visits", "other_ed_visits"],
+                ".value": [2, 8],
+            }
+        ).write_csv(data_path, separator="\t")
+
+        append_prop_data_to_combined_data(data_path)
+
+        result = pl.read_csv(data_path, separator="\t")
+        expected = pl.DataFrame(
+            {
+                "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
+                "location": ["US", "US", "US"],
+                ".variable": [
+                    "observed_ed_visits",
+                    "other_ed_visits",
+                    "prop_disease_ed_visits",
+                ],
+                ".value": [2.0, 8.0, 0.2],
+            }
+        )
+        plt.assert_frame_equal(result, expected)
 
 
 class TestCLIUtils:

--- a/pipelines/tests/utils/test_common_utils.py
+++ b/pipelines/tests/utils/test_common_utils.py
@@ -164,6 +164,39 @@ class TestDataWranglingUtils:
         )
         plt.assert_frame_equal(result, expected)
 
+    def test_append_prop_data_to_combined_data_allows_variable_names(self, tmp_path):
+        data_path = tmp_path / "combined_data.tsv"
+        pl.DataFrame(
+            {
+                "date": ["2024-01-01", "2024-01-01"],
+                "location": ["US", "US"],
+                ".variable": ["num_visits", "denom_other_visits"],
+                ".value": [3, 7],
+            }
+        ).write_csv(data_path, separator="\t")
+
+        append_prop_data_to_combined_data(
+            data_path,
+            observed_var="num_visits",
+            other_var="denom_other_visits",
+            prop_var="prop_num_visits",
+        )
+
+        result = pl.read_csv(data_path, separator="\t")
+        expected = pl.DataFrame(
+            {
+                "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
+                "location": ["US", "US", "US"],
+                ".variable": [
+                    "denom_other_visits",
+                    "num_visits",
+                    "prop_num_visits",
+                ],
+                ".value": [7.0, 3.0, 0.3],
+            }
+        )
+        plt.assert_frame_equal(result, expected)
+
 
 class TestCLIUtils:
     """Tests for CLI argument parsing utilities."""

--- a/pipelines/utils/common_utils.py
+++ b/pipelines/utils/common_utils.py
@@ -10,10 +10,10 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-from cfa.stf.data import ensure_list
-from cfa.stf.forecasttools import LOCATION_LIST
+import polars as pl
 from pyrenew_multisignal.hew import PyrenewHEWParam, build_pyrenew_hew_model
 
+from cfa.stf.forecasttools import LOCATION_LIST, append_prop_data
 from pipelines.utils.cli_utils import run_command
 
 # Disease mapping and location abbreviations
@@ -23,6 +23,12 @@ disease_map_lower_ = {
     "rsv": "RSV",
 }
 loc_abbrs_ = LOCATION_LIST
+
+
+def _format_tabular_number(value: float | None) -> str | None:
+    if value is None:
+        return None
+    return f"{value:.15g}"
 
 
 def load_credentials(
@@ -580,6 +586,8 @@ def get_all_forecast_dirs(
     ValueError
         Given an invalid ``report_date``.
     """
+    from cfa.stf.data import ensure_list
+
     diseases = ensure_list(diseases)
 
     if report_date is None:
@@ -724,13 +732,35 @@ def create_prop_samples(
 
 
 def append_prop_data_to_combined_data(data_path: Path | str) -> None:
-    args = [str(data_path)]
+    """Append disease ED visit proportion rows to a combined data file in place."""
+    path = Path(data_path)
+    suffix = path.suffix.lower()
 
-    run_r_script(
-        "pipelines/utils/append_prop_data.R",
-        args,
-        function_name="append_prop_data_to_combined_data",
-    )
+    if suffix == ".tsv":
+        data = pl.read_csv(path, separator="\t", null_values="NA")
+        result = append_prop_data(data).with_columns(
+            pl.col(".value").map_elements(
+                _format_tabular_number,
+                return_dtype=pl.String,
+            )
+        )
+        result.write_csv(path, separator="\t", null_value="NA")
+    elif suffix == ".csv":
+        data = pl.read_csv(path, null_values="NA")
+        result = append_prop_data(data).with_columns(
+            pl.col(".value").map_elements(
+                _format_tabular_number,
+                return_dtype=pl.String,
+            )
+        )
+        result.write_csv(path, null_value="NA")
+    elif suffix == ".parquet":
+        data = pl.read_parquet(path)
+        append_prop_data(data).write_parquet(path)
+    else:
+        raise ValueError(
+            "data_path must have a supported tabular extension: .tsv, .csv, or .parquet"
+        )
 
 
 def generate_epiweekly_data(data_dir: Path, overwrite_daily: bool = False) -> None:

--- a/pipelines/utils/common_utils.py
+++ b/pipelines/utils/common_utils.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import Any
 
 import polars as pl
-from cfa.stf.forecasttools import LOCATION_LIST, append_prop_data
 from pyrenew_multisignal.hew import PyrenewHEWParam, build_pyrenew_hew_model
 
+from cfa.stf.forecasttools import LOCATION_LIST, append_prop_data
 from pipelines.utils.cli_utils import run_command
 
 # Disease mapping and location abbreviations
@@ -23,12 +23,6 @@ disease_map_lower_ = {
     "rsv": "RSV",
 }
 loc_abbrs_ = LOCATION_LIST
-
-
-def _format_tabular_number(value: float | None) -> str | None:
-    if value is None:
-        return None
-    return f"{value:.15g}"
 
 
 def load_credentials(
@@ -738,22 +732,10 @@ def append_prop_data_to_combined_data(data_path: Path | str) -> None:
 
     if suffix == ".tsv":
         data = pl.read_csv(path, separator="\t", null_values="NA")
-        result = append_prop_data(data).with_columns(
-            pl.col(".value").map_elements(
-                _format_tabular_number,
-                return_dtype=pl.String,
-            )
-        )
-        result.write_csv(path, separator="\t", null_value="NA")
+        append_prop_data(data).write_csv(path, separator="\t", null_value="NA")
     elif suffix == ".csv":
         data = pl.read_csv(path, null_values="NA")
-        result = append_prop_data(data).with_columns(
-            pl.col(".value").map_elements(
-                _format_tabular_number,
-                return_dtype=pl.String,
-            )
-        )
-        result.write_csv(path, null_value="NA")
+        append_prop_data(data).write_csv(path, null_value="NA")
     elif suffix == ".parquet":
         data = pl.read_parquet(path)
         append_prop_data(data).write_parquet(path)

--- a/pipelines/utils/common_utils.py
+++ b/pipelines/utils/common_utils.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import Any
 
 import polars as pl
-from cfa.stf.forecasttools import LOCATION_LIST, append_prop_data
 from pyrenew_multisignal.hew import PyrenewHEWParam, build_pyrenew_hew_model
 
+from cfa.stf.forecasttools import LOCATION_LIST, append_prop_data
 from pipelines.utils.cli_utils import run_command
 
 # Disease mapping and location abbreviations
@@ -732,17 +732,22 @@ def append_prop_data_to_combined_data(data_path: Path | str) -> None:
 
     if suffix == ".tsv":
         data = pl.read_csv(path, separator="\t", null_values="NA")
-        append_prop_data(data).write_csv(path, separator="\t", null_value="NA")
     elif suffix == ".csv":
         data = pl.read_csv(path, null_values="NA")
-        append_prop_data(data).write_csv(path, null_value="NA")
     elif suffix == ".parquet":
         data = pl.read_parquet(path)
-        append_prop_data(data).write_parquet(path)
     else:
         raise ValueError(
             "data_path must have a supported tabular extension: .tsv, .csv, or .parquet"
         )
+
+    data = append_prop_data(data)
+    if suffix == ".tsv":
+        data.write_csv(path, separator="\t", null_value="NA")
+    elif suffix == ".csv":
+        data.write_csv(path, null_value="NA")
+    elif suffix == ".parquet":
+        data.write_parquet(path)
 
 
 def generate_epiweekly_data(data_dir: Path, overwrite_daily: bool = False) -> None:

--- a/pipelines/utils/common_utils.py
+++ b/pipelines/utils/common_utils.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import Any
 
 import polars as pl
-from cfa.stf.forecasttools import LOCATION_LIST, append_prop_data
 from pyrenew_multisignal.hew import PyrenewHEWParam, build_pyrenew_hew_model
 
+from cfa.stf.forecasttools import LOCATION_LIST, append_prop_data
 from pipelines.utils.cli_utils import run_command
 
 # Disease mapping and location abbreviations

--- a/pipelines/utils/common_utils.py
+++ b/pipelines/utils/common_utils.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import Any
 
 import polars as pl
-from cfa.stf.forecasttools import LOCATION_LIST, append_prop_data
 from pyrenew_multisignal.hew import PyrenewHEWParam, build_pyrenew_hew_model
 
+from cfa.stf.forecasttools import LOCATION_LIST, append_prop_data
 from pipelines.utils.cli_utils import run_command
 
 # Disease mapping and location abbreviations
@@ -725,7 +725,12 @@ def create_prop_samples(
     )
 
 
-def append_prop_data_to_combined_data(data_path: Path | str) -> None:
+def append_prop_data_to_combined_data(
+    data_path: Path | str,
+    observed_var: str = "observed_ed_visits",
+    other_var: str = "other_ed_visits",
+    prop_var: str = "prop_disease_ed_visits",
+) -> None:
     """Append disease ED visit proportion rows to a combined data file in place."""
     path = Path(data_path)
     suffix = path.suffix.lower()
@@ -741,7 +746,12 @@ def append_prop_data_to_combined_data(data_path: Path | str) -> None:
             "data_path must have a supported tabular extension: .tsv, .csv, or .parquet"
         )
 
-    data = append_prop_data(data)
+    data = append_prop_data(
+        data,
+        observed_var=observed_var,
+        other_var=other_var,
+        prop_var=prop_var,
+    )
     if suffix == ".tsv":
         data.write_csv(path, separator="\t", null_value="NA")
     elif suffix == ".csv":

--- a/pipelines/utils/common_utils.py
+++ b/pipelines/utils/common_utils.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import Any
 
 import polars as pl
+from cfa.stf.forecasttools import LOCATION_LIST, append_prop_data
 from pyrenew_multisignal.hew import PyrenewHEWParam, build_pyrenew_hew_model
 
-from cfa.stf.forecasttools import LOCATION_LIST, append_prop_data
 from pipelines.utils.cli_utils import run_command
 
 # Disease mapping and location abbreviations

--- a/uv.lock
+++ b/uv.lock
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "cfa-stf-forecasttools"
 version = "0.1.0"
-source = { git = "https://github.com/CDCgov/cfa-stf-forecasttools?rev=main#9f569bb23277925a688df3bb3378e1f379b1b5eb" }
+source = { git = "https://github.com/CDCgov/cfa-stf-forecasttools?rev=main#32e7a058034ddf906d1217613e70c4f93b03e695" }
 dependencies = [
     { name = "numpy" },
     { name = "polars", extra = ["numpy", "pyarrow"] },


### PR DESCRIPTION
## Summary

Replaces the `append_prop_data.R` call path with Python file I/O in `append_prop_data_to_combined_data()`, using the new `cfa.stf.forecasttools.append_prop_data()` helper.

The routine pipeline keeps ownership of reading and writing combined-data files, formats CSV/TSV `.value` output to match the legacy `readr::write_tsv` representation, and leaves parquet output numeric.

This PR depends on CDCgov/cfa-stf-forecasttools#221 being merged first.

## Validation

- `uv run python -c "import sys; sys.path.insert(0, '/Users/damon/Documents/GitHub/forecasttools-py'); import pytest; raise SystemExit(pytest.main(['pipelines/tests/utils/test_common_utils.py']))"`
- Compared legacy R script output with the new Python routine function on the same TSV fixture; outputs were byte-identical and parsed tables matched.
