### PR TITLE
Fixes config_override bug described in #1174

### DIFF
--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -9,9 +9,6 @@ from zoneinfo import ZoneInfo
 
 # Direct use of dagster
 import dagster as dg
-
-# Helper Libraries
-from cfa.stf.forecasttools import LOCATION_LIST
 from cfa_dagster import (
     ADLS2PickleIOManager,
     ExecutionConfig,
@@ -31,6 +28,9 @@ from cfa_dagster import (
 from pydantic import BaseModel, Field
 from pygit2.repository import Repository
 from pyrenew_multisignal.hew.utils import flags_from_hew_letters
+
+# Helper Libraries
+from cfa.stf.forecasttools import LOCATION_LIST
 
 # Model Code
 from pipelines.fable.forecast_fable import main as forecast_fable
@@ -233,11 +233,12 @@ class ModelBaseConfig(_ModelTrainingFields, dg.ConfigurableResource):
     )  # type: ignore[reportInvalidTypeForm]
 
     def get_by_location(self, loc: Location) -> "ModelBaseConfig":  # type: ignore[reportInvalidTypeForm]
-        """Returns location-specific config if provided via config_overrides"""
         overrides = {}
         for entry in self.config_overrides:
-            if entry["location"] == loc:
-                overrides = {k: v for k, v in entry.items() if k != "location"}
+            if isinstance(entry, dict):
+                entry = ConfigOverride(**entry)
+            if entry.location == loc:
+                overrides = entry.model_dump(exclude={"location"})
                 break
         return self.model_copy(update=overrides)
 

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -9,6 +9,9 @@ from zoneinfo import ZoneInfo
 
 # Direct use of dagster
 import dagster as dg
+
+# Helper Libraries
+from cfa.stf.forecasttools import LOCATION_LIST
 from cfa_dagster import (
     ADLS2PickleIOManager,
     ExecutionConfig,
@@ -28,9 +31,6 @@ from cfa_dagster import (
 from pydantic import BaseModel, Field
 from pygit2.repository import Repository
 from pyrenew_multisignal.hew.utils import flags_from_hew_letters
-
-# Helper Libraries
-from cfa.stf.forecasttools import LOCATION_LIST
 
 # Model Code
 from pipelines.fable.forecast_fable import main as forecast_fable

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -238,7 +238,7 @@ class ModelBaseConfig(_ModelTrainingFields, dg.ConfigurableResource):
             if isinstance(entry, dict):
                 entry = ConfigOverride(**entry)
             if entry.location == loc:
-                overrides = entry.model_dump(exclude={"location"})
+                overrides = entry.model_dump(exclude={"location"}, exclude_unset=True)
                 break
         return self.model_copy(update=overrides)
 

--- a/uv.lock
+++ b/uv.lock
@@ -841,7 +841,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "arviz", extras = ["h5netcdf"], git = "https://github.com/arviz-devs/arviz?rev=main" },
-    { name = "cfa-cloudops", git = "https://github.com/CDCgov/cfa-cloudops" },
+    { name = "cfa-cloudops", git = "https://github.com/CDCgov/cfa-cloudops?rev=main" },
     { name = "cfa-dagster", git = "https://github.com/cdcgov/cfa-dagster?rev=v1.4.0" },
     { name = "cfa-stf-data", git = "https://github.com/CDCgov/cfa-stf-data?rev=main" },
     { name = "cfa-stf-forecasttools", git = "https://github.com/CDCgov/cfa-stf-forecasttools?rev=main" },
@@ -3291,7 +3291,7 @@ wheels = [
 [[package]]
 name = "polarbayes"
 version = "0.1.0"
-source = { git = "https://github.com/cdcgov/polarbayes?rev=main#33a353198166c07de0d39b4a1f2ae9dce3f52082" }
+source = { git = "https://github.com/cdcgov/polarbayes?rev=main#4ea9857713c013fb34183355794bdd43b9af25f0" }
 dependencies = [
     { name = "arviz-base", extra = ["h5netcdf"] },
     { name = "polars" },


### PR DESCRIPTION
Fixes #1174, see issue for details.

Tested on the central server here: https://dagster.apps.edav.ext.cdc.gov/runs/a6629727-fac2-44b1-abfc-05dedcae6e00?logFileKey=kyqeydco&selection=name%3A%22fable_e_other.fable_e_other__compute%5Bx_COVID_2D_19___x_GA%5D%22&logs=query%3Aname%3A%22fable_e_other.fable_e_other__compute%5Bx_COVID_2D_19___x_GA%5D%22

Confirmed by running with the field description example of GA, exlude_last_n_days: 2. It's hard to see in the screenshot, but easily verifiable from the run link that exclude_last_n_days is showing 2 for GA.
<img width="1174" height="454" alt="image" src="https://github.com/user-attachments/assets/3c882339-02fc-4cc3-ab68-43b29a985628" />
