### PR TITLE
Restore urca dependency for Fable

### DIFF
--- a/pipelines/fable/fit_fable.R
+++ b/pipelines/fable/fit_fable.R
@@ -10,7 +10,8 @@ script_packages <- c(
   "argparser",
   "rlang",
   "stfroutineforecasting",
-  "forecasttools"
+  "forecasttools",
+  "urca"
 )
 
 ## load in packages without messages

--- a/stfroutineforecasting/DESCRIPTION
+++ b/stfroutineforecasting/DESCRIPTION
@@ -30,7 +30,8 @@ Imports:
     tibble,
     tidybayes,
     tidyr,
-    tidyselect
+    tidyselect,
+    urca
 Additional_repositories: https://hubverse-org.r-universe.dev
 Remotes:
     github::cdcgov/forecasttools,


### PR DESCRIPTION
## Summary

- restore `urca` to the R package Imports using `usethis::use_package()`
- explicitly load `urca` in the Fable forecasting script

## Root cause

Fable's automatic ARIMA differencing calls `feasts::unitroot_kpss()`, which requires the suggested `urca` package. Removing `urca` from the local package Imports meant clean production images did not install it. The ARIMA component then failed inside `comb_model`, generated missing samples, and surfaced as `missing value where TRUE/FALSE needed`.

## Validation

- reproduced the production error locally after removing `urca`
- reinstalled `urca` and ran `just test-fable` with real DataOps inputs: `1 passed`
- `git diff --check`
