### PR TITLE
Align CI R dependencies with production

### DIFF
--- a/.github/actions/setup-routine-forecasting-r/action.yaml
+++ b/.github/actions/setup-routine-forecasting-r/action.yaml
@@ -1,6 +1,10 @@
 name: "Set up routine forecasting R"
 description: "Set up R and install the stfroutineforecasting package."
-inputs: {}
+inputs:
+  dependencies:
+    description: "R dependency types to install, expressed as an R value."
+    required: false
+    default: "NA"
 runs:
   using: "composite"
   steps:
@@ -17,6 +21,7 @@ runs:
         working-directory: stfroutineforecasting
         needs: check, coverage
         extra-packages: any::covr, any::xml2
+        dependencies: ${{ inputs.dependencies }}
 
     - name: Install stfroutineforecasting
       run: pak::local_install("stfroutineforecasting", ask = FALSE, upgrade = FALSE)

--- a/.github/actions/setup-routine-forecasting-r/action.yaml
+++ b/.github/actions/setup-routine-forecasting-r/action.yaml
@@ -4,7 +4,7 @@ inputs:
   dependencies:
     description: "R dependency types to install, expressed as an R value."
     required: false
-    default: "NA"
+    default: '"hard"'
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -31,6 +31,8 @@ jobs:
 
     - name: Set up routine forecasting R
       uses: ./.github/actions/setup-routine-forecasting-r
+      with:
+        dependencies: '"all"'
 
     - name: "Check stfroutineforecasting package"
       uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Set up routine forecasting R
         uses: ./.github/actions/setup-routine-forecasting-r
+        with:
+          dependencies: '"all"'
 
       - name: Test coverage
         run: |


### PR DESCRIPTION
## Summary

- make the shared GitHub Actions R setup install hard dependencies by default, matching the production Docker image
- keep `dependencies = "all"` for R CMD check and R package coverage jobs that need suggested development dependencies

## Motivation

PR #1195 removed `urca` from this package's Imports, but CI continued installing it through the transitive Suggests of `fable` and `feasts`. As a result, the Fable integration test passed in GitHub Actions while the production image failed at runtime.

Using hard dependencies for model and pipeline CI jobs makes missing runtime declarations visible before deployment without reducing the dependency set used for package-development checks.

## Validation

- repository pre-commit hooks passed for all changed files
- YAML validation passed
- `git diff --check`


Closes https://github.com/CDCgov/cfa-stf-routine-forecasting/issues/1207