### PR TITLE
Drop data_type from model inputs

### DIFF
--- a/pipelines/data/prep_data.py
+++ b/pipelines/data/prep_data.py
@@ -103,12 +103,12 @@ def process_and_save_loc_data(
         "right_truncation_offset": forecast_data.right_truncation_offset,
         "nwss_training_data": None,
         "nssp_training_data": (
-            nssp_training_data.drop("resolution").to_dict(as_series=False)
+            nssp_training_data.drop("resolution", "data_type").to_dict(as_series=False)
             if nssp_training_data is not None
             else None
         ),
         "nhsn_training_data": (
-            nhsn_training_data.drop("resolution").to_dict(as_series=False)
+            nhsn_training_data.drop("resolution", "data_type").to_dict(as_series=False)
             if nhsn_training_data is not None
             else None
         ),

--- a/pipelines/fable/fit_fable.R
+++ b/pipelines/fable/fit_fable.R
@@ -27,8 +27,7 @@ purrr::walk(script_packages, \(pkg) {
 #' This function fits a combination ensemble model to the training data and
 #' generates forecast samples for a specified number of days.
 #'
-#' @param data A data frame containing the time series data. It should have a
-#' column named `data_type` to distinguish between training and other data.
+#' @param data A data frame containing only the training time series data.
 #' @param n_forecast_days An integer specifying the number of days to forecast.
 #' Default is 28.
 #' @param n_samples An integer specifying the number of forecast samples to
@@ -54,7 +53,6 @@ fit_and_forecast_ensemble <- function(
 
   fit <- data |>
     as_tsibble(index = date) |>
-    filter(data_type == "train") |>
     model(
       comb_model = combination_ensemble(
         ETS(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ override-dependencies = [
 [tool.uv.sources]
 cfa-dagster = { git = "https://github.com/cdcgov/cfa-dagster", rev = "v1.4.0" }
 cfa-cloudops = { git = "https://github.com/CDCgov/cfa-cloudops.git" }
-pyrenew-multisignal = {git = "https://github.com/CDCgov/pyrenew-multisignal", rev = "5938ec3"}
+pyrenew-multisignal = {git = "https://github.com/CDCgov/pyrenew-multisignal", rev = "1c9fa48"}
 polarbayes = { git = "https://github.com/cdcgov/polarbayes", rev = "main" }
 arviz = { git = "https://github.com/arviz-devs/arviz", rev = "main" }
 arviz-base = { git = "https://github.com/arviz-devs/arviz-base", rev = "main" }

--- a/stfroutineforecasting/R/timeseries_utils.R
+++ b/stfroutineforecasting/R/timeseries_utils.R
@@ -37,7 +37,7 @@ load_training_data <- function(
     )
   ) |>
     dplyr::filter(.data$data_type == "train") |>
-    dplyr::select(-"lab_site_index") |>
+    dplyr::select(-"lab_site_index", -"data_type") |>
     dplyr::filter(stringr::str_ends(.data$.variable, "ed_visits")) |>
     tidyr::pivot_wider(names_from = ".variable", values_from = ".value")
 

--- a/stfroutineforecasting/tests/testthat/test_timeseries_utils.R
+++ b/stfroutineforecasting/tests/testthat/test_timeseries_utils.R
@@ -11,6 +11,40 @@ common_required_columns <- c(
 
 base_date <- as.Date("2024-01-01")
 
+test_that("load_training_data returns training rows without data_type", {
+  withr::with_tempdir({
+    model_dir <- fs::path(
+      "covid-19_r_2024-01-03_f_2024-01-01_t_2024-01-02",
+      "model_runs",
+      "CA",
+      "fable_e_daily"
+    )
+    fs::dir_create(fs::path(model_dir, "data"))
+    input_data <- tibble::tibble(
+      date = rep(base_date + 0:2, each = 2),
+      geo_value = "CA",
+      disease = "COVID-19",
+      data_type = rep(c("train", "train", "eval"), each = 2),
+      .variable = rep(c("observed_ed_visits", "other_ed_visits"), 3),
+      .value = c(10, 90, 11, 99, 12, 108),
+      lab_site_index = NA_integer_,
+      resolution = "daily"
+    )
+    readr::write_tsv(
+      input_data,
+      fs::path(model_dir, "data", "combined_data.tsv")
+    )
+
+    result <- load_training_data(model_dir)
+
+    expect_equal(result$data$date, base_date + 0:1)
+    expect_false("data_type" %in% colnames(result$data))
+    expect_equal(result$geo_value, "CA")
+    expect_equal(result$disease, "COVID-19")
+    expect_equal(result$resolution, "daily")
+  })
+})
+
 test_that("format_timeseries_output formats forecast data correctly", {
   # Create minimal test data
   forecast_data <- tibble::tibble(

--- a/uv.lock
+++ b/uv.lock
@@ -855,7 +855,7 @@ requires-dist = [
     { name = "pygit2", specifier = ">=1.17.0" },
     { name = "pypdf", specifier = ">=6.10.1" },
     { name = "pyrenew" },
-    { name = "pyrenew-multisignal", git = "https://github.com/CDCgov/pyrenew-multisignal?rev=5938ec3" },
+    { name = "pyrenew-multisignal", git = "https://github.com/CDCgov/pyrenew-multisignal?rev=1c9fa48" },
     { name = "tomli-w", specifier = ">=1.1.0" },
 ]
 
@@ -3694,7 +3694,7 @@ wheels = [
 [[package]]
 name = "pyrenew"
 version = "0.1.7"
-source = { git = "https://github.com/CDCgov/PyRenew?rev=v0.1.7#ef83fbb7f65d1131fd1f37935ce655a1268c8edf" }
+source = { git = "https://github.com/CDCgov/PyRenew?rev=69b92d6#69b92d6b3ba70387e9cbf1c40aea42a835994a9f" }
 dependencies = [
     { name = "jax" },
     { name = "numpy" },
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "pyrenew-multisignal"
 version = "0.1.0"
-source = { git = "https://github.com/CDCgov/pyrenew-multisignal?rev=5938ec3#5938ec3260cec14050fa787d6b192726d7ace7d8" }
+source = { git = "https://github.com/CDCgov/pyrenew-multisignal?rev=1c9fa48#1c9fa48d2435a0fbcf45716cc5713d77c52c9f91" }
 dependencies = [
     { name = "jax" },
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- omit `data_type` from the already-filtered data in `data_for_model_fit.json`
- remove downstream training-data filtering from the Fable model
- keep training/evaluation handling at the `combined_data.tsv` boundary
- update `pyrenew-multisignal` to the version that accepts inputs without `data_type`

Closes #1188.

## Testing

- `uv run pytest pipelines/tests -m 'not model_integration and not pipeline_e2e' -q`
- `uv run pytest pipelines/tests/integration/test_pyrenew_forecast.py -m model_integration -q`
- `Rscript -e 'devtools::test("stfroutineforecasting")'`
- targeted pre-commit checks
