### PR TITLE
Improve nowcast applicability errors

### DIFF
--- a/pipelines/data/hubverse_nowcast.py
+++ b/pipelines/data/hubverse_nowcast.py
@@ -42,13 +42,20 @@ class HubverseNowcast:
         object.__setattr__(self, "containing_dir", Path(self.containing_dir))
 
     @staticmethod
-    def applies_to(*, forecast_spec: ForecastSpec) -> bool:
+    def ensure_applicable(*, forecast_spec: ForecastSpec) -> None:
         """Whether Hubverse NHSN sample output matches the requested model."""
-        return (
-            forecast_spec.target == "nhsn"
-            and forecast_spec.frequency == "epiweekly"
-            and forecast_spec.ed_visit_type == "observed"
-        )
+        if (
+            forecast_spec.target != "nhsn"
+            or forecast_spec.frequency != "epiweekly"
+            or forecast_spec.ed_visit_type != "observed"
+        ):
+            raise ValueError(
+                "Hubverse nowcasting is only applicable when target='nhsn', "
+                "frequency='epiweekly', and ed_visit_type='observed'; got "
+                f"target={forecast_spec.target!r}, "
+                f"frequency={forecast_spec.frequency!r}, and "
+                f"ed_visit_type={forecast_spec.ed_visit_type!r}."
+            )
 
     def _artifact_path(self) -> Path:
         model_output_dir = self.containing_dir / HUBVERSE_MODEL_OUTPUT_SUBDIR

--- a/pipelines/data/nowcast.py
+++ b/pipelines/data/nowcast.py
@@ -21,12 +21,12 @@ class NowcastData:
 class NowcastSource(Protocol):
     """Interface for producing nowcast data for a forecast configuration."""
 
-    def applies_to(
+    def ensure_applicable(
         self,
         *,
         forecast_spec: ForecastSpec,
-    ) -> bool:
-        """Whether this source applies to a forecast configuration."""
+    ) -> None:
+        """Ensure this source applies to a forecast configuration."""
         ...
 
     def get_nowcast_data(

--- a/pipelines/epiautogp/README.md
+++ b/pipelines/epiautogp/README.md
@@ -70,7 +70,7 @@ Shared utilities for the forecast pipeline, containing modular functions for eac
 Pluggable nowcasting sources for nowcasting recent observations.
 
 - **`NowcastData`** (`../data/nowcast.py`): Stores nowcast dates and report trajectories.
-- **`NowcastSource`** (`../data/nowcast.py`): Protocol declaring `applies_to(*, forecast_spec) -> bool` (the predicate the resolver queries before constructing) and `get_nowcast_data(*, dates, reports) -> NowcastData` (the action).
+- **`NowcastSource`** (`../data/nowcast.py`): Protocol declaring `ensure_applicable(*, forecast_spec) -> None` and `get_nowcast_data(*, dates, reports) -> NowcastData` (the action).
 - **`FixedNowcast`**: Trivial source wrapping a precomputed `NowcastData`.
 - **`ReportingDelayNowcast`**: Inflates the most-recent observations by the inverse of a reporting-delay PMF.
   Applies to count series (rejects `ed_visit_type="pct"`); warns when used on a non-daily series since the PMF support is daily by convention.

--- a/pipelines/epiautogp/epiautogp_forecast_utils.py
+++ b/pipelines/epiautogp/epiautogp_forecast_utils.py
@@ -183,21 +183,13 @@ def _resolve_nowcast_source(
         case "none":
             return None
         case "reporting-delay":
-            if not ReportingDelayNowcast.applies_to(forecast_spec=forecast_spec):
-                raise ValueError(
-                    f"reporting-delay nowcasting is not applicable to "
-                    f"target={forecast_spec.target!r}, ed_visit_type={forecast_spec.ed_visit_type!r}."
-                )
+            ReportingDelayNowcast.ensure_applicable(forecast_spec=forecast_spec)
             return _build_reporting_delay_nowcast(
                 forecast_spec=forecast_spec,
                 reporting_delay_pmf=reporting_delay_pmf,
             )
         case "hubverse":
-            if not HubverseNowcast.applies_to(forecast_spec=forecast_spec):
-                raise ValueError(
-                    "hubverse nowcasting is only applicable to NHSN "
-                    "epiweekly observed counts."
-                )
+            HubverseNowcast.ensure_applicable(forecast_spec=forecast_spec)
             if hubverse_nowcast_dir is None:
                 raise ValueError(
                     "hubverse_nowcast_dir is required when Hubverse nowcasting is "

--- a/pipelines/epiautogp/nowcast.py
+++ b/pipelines/epiautogp/nowcast.py
@@ -18,11 +18,11 @@ class FixedNowcast:
     data: NowcastData
 
     @staticmethod
-    def applies_to(
+    def ensure_applicable(
         *,
         forecast_spec: ForecastSpec,
-    ) -> bool:
-        return True
+    ) -> None:
+        pass
 
     def get_nowcast_data(
         self,

--- a/pipelines/epiautogp/reporting_delay_nowcast.py
+++ b/pipelines/epiautogp/reporting_delay_nowcast.py
@@ -36,10 +36,10 @@ class ReportingDelayNowcast:
     reporting_delay_pmf: list[float]
 
     @staticmethod
-    def applies_to(
+    def ensure_applicable(
         *,
         forecast_spec: ForecastSpec,
-    ) -> bool:
+    ) -> None:
         # The estimator multiplies recent observations by 1/reporting_fraction.
         # For a percentage (numerator / denominator) the same factor applies to
         # both terms and cancels, so reject ed_visit_type="pct". Target and
@@ -52,7 +52,13 @@ class ReportingDelayNowcast:
                 forecast_spec.frequency,
             )
 
-        return forecast_spec.ed_visit_type != "pct"
+        if forecast_spec.ed_visit_type == "pct":
+            raise ValueError(
+                "Reporting-delay nowcasting is not applicable when "
+                "ed_visit_type='pct': applying the same reporting-delay "
+                "inflation factor to the numerator and denominator would "
+                "cancel out."
+            )
 
     def get_nowcast_data(
         self,

--- a/pipelines/tests/data/test_hubverse_nowcast.py
+++ b/pipelines/tests/data/test_hubverse_nowcast.py
@@ -136,6 +136,19 @@ def test_resolver_builds_source_for_materialized_directory(tmp_path):
 
 
 @pytest.mark.parametrize(
+    ("spec", "invalid_setting"),
+    [
+        (_spec(target="nssp"), "target='nssp'"),
+        (_spec(frequency="daily"), "frequency='daily'"),
+        (_spec(ed_visit_type="pct"), "ed_visit_type='pct'"),
+    ],
+)
+def test_validation_explains_inapplicable_model_configuration(spec, invalid_setting):
+    with pytest.raises(ValueError, match=invalid_setting):
+        HubverseNowcast.ensure_applicable(forecast_spec=spec)
+
+
+@pytest.mark.parametrize(
     "spec",
     [
         _spec(target="nssp"),
@@ -143,7 +156,7 @@ def test_resolver_builds_source_for_materialized_directory(tmp_path):
         _spec(ed_visit_type="pct"),
     ],
 )
-def test_resolver_rejects_inapplicable_model_configuration(tmp_path, spec):
+def test_resolver_propagates_applicability_error(tmp_path, spec):
     with pytest.raises(ValueError, match="only applicable"):
         _resolve_nowcast_source(
             forecast_spec=spec,

--- a/pipelines/tests/epiautogp/test_reporting_delay_nowcast.py
+++ b/pipelines/tests/epiautogp/test_reporting_delay_nowcast.py
@@ -18,7 +18,7 @@ from pipelines.epiautogp.reporting_delay_nowcast import ReportingDelayNowcast
 def _spec(
     *, target: str = "nssp", ed_visit_type: str = "observed", frequency: str = "daily"
 ) -> ForecastSpec:
-    """Build a ForecastSpec varying only the fields applies_to cares about."""
+    """Build a ForecastSpec varying only the applicability fields."""
     return ForecastSpec(
         disease="COVID-19",
         loc="CA",
@@ -61,24 +61,32 @@ class TestInflateReport:
             inflate_report(1.0, -0.1)
 
 
-class TestReportingDelayNowcastAppliesTo:
+class TestReportingDelayNowcastEnsureApplicable:
     @pytest.mark.parametrize(
-        ("target", "ed_visit_type", "expected"),
+        ("target", "ed_visit_type"),
         [
-            ("nssp", "observed", True),
-            ("nssp", "other", True),
-            ("nssp", "pct", False),
+            ("nssp", "observed"),
+            ("nssp", "other"),
             # NHSN has no ed_visit_type concept; the parameter defaults to
             # "observed" upstream and the source happily applies to its counts.
-            ("nhsn", "observed", True),
+            ("nhsn", "observed"),
         ],
     )
-    def test_applies_to(self, target, ed_visit_type, expected):
+    def test_accepts_count_targets(self, target, ed_visit_type):
         # Only ed_visit_type is gating; target and frequency are carried in the
         # spec for protocol compatibility but ignored here. The resolver
         # enforces daily cadence via a soft warning.
         spec = _spec(target=target, ed_visit_type=ed_visit_type, frequency="daily")
-        assert ReportingDelayNowcast.applies_to(forecast_spec=spec) is expected
+        assert ReportingDelayNowcast.ensure_applicable(forecast_spec=spec) is None
+
+    def test_percentage_target_raises_with_explanation(self):
+        spec = _spec(ed_visit_type="pct")
+
+        with pytest.raises(
+            ValueError,
+            match="same reporting-delay inflation factor.*would cancel out",
+        ):
+            ReportingDelayNowcast.ensure_applicable(forecast_spec=spec)
 
 
 class TestReportingDelayNowcastGetNowcastData:
@@ -149,8 +157,8 @@ class TestReportingDelayNowcastGetNowcastData:
 
 
 class TestFixedNowcast:
-    def test_applies_to_always_true(self):
-        assert FixedNowcast.applies_to(forecast_spec=_spec()) is True
+    def test_ensure_applicable_accepts_any_spec(self):
+        assert FixedNowcast.ensure_applicable(forecast_spec=_spec()) is None
 
     def test_returns_stored_data(self):
         data = NowcastData(dates=[dt.date(2024, 1, 1)], reports=[[1.0]])


### PR DESCRIPTION
## Summary

- Replace the `applies_to` predicate with `ensure_applicable`, which returns normally for supported configurations and raises `ValueError` otherwise.
- Move applicability error construction into each nowcast source so errors include the relevant configuration and reason.
- Simplify the nowcast resolver to propagate source-specific errors.
- Update tests and documentation for the new method contract.

## Why

Applicability rules lived in each nowcast source, but failures were reported by the resolver using generic messages. This separated validation from its error context and made failures less informative.

## User impact

Invalid nowcast configurations now fail with actionable messages describing the unsupported values or why the source cannot be applied.

## Testing

- `uv run ruff check ...`
- `uv run ruff format --check ...`
- `uv run pytest -q pipelines/tests --ignore=pipelines/tests/integration` — 135 passed

Closes #1204
